### PR TITLE
Asynchronous secret validation

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -53,7 +53,10 @@ if (args.dev) {
     // We also turn off the timeout in dev; it's not as important there.
     fetchPackage.setTimeout(null);
     // Disable the need for secrets.
-    renderSecret.matches = (actual) => true;
+    renderSecret.matches = (actual, callback) => {
+      return callback(null, true);
+    };
+
     process.env.NODE_ENV = 'dev';
 } else {
     // This is important for the default catch-all error handler:
@@ -93,4 +96,3 @@ const server = appWithLogging.listen(port, () => {
 
     logging.info('react-render-server running at http://%s:%s', host, port);
 });
-

--- a/src/secret.js
+++ b/src/secret.js
@@ -22,9 +22,10 @@ let secret;
 // Used by the benchmark/loadtest tool.
 const get = function(done) {
   if (secret) {
-    return done(null, done);
+    return done(null, secret);
   }
-  fs.readFile(secretPath, "utf-8", (err, contents) =>{
+
+  fs.readFile(secretPath, "utf-8", (err, contents) => {
     if (err) {
       logging.error(`FATAL ERROR (${err}): You must create a file:`);
       logging.error('    ' + secretPath);
@@ -33,23 +34,23 @@ const get = function(done) {
       return done(err);
     }
 
-    var secret = contents.trim();
+    secret = contents.trim();
     if (!secret) {
         return done(new Error('secret file is empty!'));
     }
 
-    return done(secret);
+    return done(null, secret);
   });
 };
 
 
 const matches = function(actual, done) {
-    return get((err, secret) =>{
+    return get((err, secret) => {
       if (err) {
         return done(err);
       }
 
-      return done(secret === actual);
+      return done(null, secret === actual);
     });
 };
 

--- a/src/secret_test.js
+++ b/src/secret_test.js
@@ -1,0 +1,70 @@
+'use strict';
+/* global describe, it, before, beforeEach, afterEach, after */
+
+const fs = require("fs");
+
+const assert = require("chai").assert;
+const logging = require("winston");
+const nock = require("nock");
+const sinon = require("sinon");
+const supertest = require("supertest");
+const renderSecret = require("./secret.js");
+const server = require("./server.js");
+
+describe('secret', () => {
+    const agent = supertest.agent(server);
+    beforeEach(() => {
+      sinon.stub(fs, 'readFile', (filePath, encoding, callback) => {
+        return callback(null, "sekret");
+      });
+    });
+
+    afterEach(() => {
+        fs.readFile.restore();
+    });
+
+
+    it ("can handle missing secret file", (done) => {
+      fs.readFile.restore();
+      sinon.stub(fs, 'readFile', (filePath, encoding, callback) => {
+        return callback(new Error("File not found"));
+      });
+
+      renderSecret.matches("sekret", (err, valueMatches) => {
+        assert.equal(err.message, "File not found");
+        done();
+      });
+    });
+
+    it ("can handle empty secret file", (done) => {
+      fs.readFile.restore();
+      sinon.stub(fs, 'readFile', (filePath, encoding, callback) => {
+        return callback(null, "");
+      });
+
+      renderSecret.matches("sekret", (err, valueMatches) => {
+        assert.equal(err.message, "secret file is empty!");
+        done();
+      });
+    });
+
+    it ("can match secret to actual value", (done) => {
+      renderSecret.matches("sekret", (err, valueMatches) => {
+        assert.equal(valueMatches, true, "Should match secret value ");
+        done();
+      });
+    });
+
+    it ("can match cached secret to actual value", (done) => {
+      // On the second run through, the fs.readFile function should not be called.
+      fs.readFile.restore();
+      sinon.stub(fs, 'readFile', (filePath, encoding, callback) => {
+        return callback(new Error("Should not be called"));
+      });
+
+      renderSecret.matches("sekret", (err, valueMatches) => {
+        assert.equal(valueMatches, true, "Should match secret value ");
+        done();
+      });
+    });
+});

--- a/src/server.js
+++ b/src/server.js
@@ -112,9 +112,7 @@ app.use('/render', (req, res, next) => {
 const checkSecret = function (req, res, next) {
   renderSecret.matches(req.body.secret, (err, secretMatches) => {
     if (err || !secretMatches) {
-      var error  = new Error("Missing or invalid secret");
-      error.status = 400;
-      return next(error);
+      return res.status(400).send({error: "Missing or invalid secret"});
     }
     return next();
   });

--- a/src/server.js
+++ b/src/server.js
@@ -222,4 +222,3 @@ app.get('/_ah/stop', (req, res) => res.send('ok!\n'));
 
 
 module.exports = app;
-

--- a/src/server.js
+++ b/src/server.js
@@ -109,14 +109,22 @@ app.use('/render', (req, res, next) => {
     next();
 });
 
-app.post('/render', (req, res) => {
+const checkSecret = function (req, res, next) {
+  renderSecret.matches(req.body.secret, (err, secretMatches) => {
+    if (err || !secretMatches) {
+      var error  = new Error("Missing or invalid secret");
+      error.status = 400;
+      return next(error);
+    }
+    return next();
+  });
+};
+
+app.post('/render', checkSecret, (req, res) => {
     // Validate the input.
     let err;
     let value;
-    if (!renderSecret.matches(req.body.secret)) {
-        err = 'Missing or invalid secret';
-        value = '<redacted>';
-    } else if (!Array.isArray(req.body.urls) || req.body.urls.length === 0 ||
+    if (!Array.isArray(req.body.urls) || req.body.urls.length === 0 ||
                !req.body.urls.every(e => typeof e === 'string') ||
                !req.body.urls.every(e => e.indexOf('http') === 0)) {
         err = ('Missing "urls" keyword in POST JSON input, ' +
@@ -198,11 +206,7 @@ app.post('/render', (req, res) => {
  * We respond with the instance that was flushed.
  * TODO(csilvers): how do we flush *all* the instances??
  */
-app.post('/flush', (req, res) => {
-    if (!renderSecret.matches(req.body.secret)) {
-        res.status(400).json({error: 'Missing or invalid secret'});
-        return;
-    }
+app.post('/flush', checkSecret, (req, res) => {
     cache.reset();
     res.send((process.env['GAE_MODULE_INSTANCE'] || 'dev') + '\n');
 });

--- a/src/server_test.js
+++ b/src/server_test.js
@@ -91,7 +91,9 @@ describe('API endpoint /render', () => {
     beforeEach(() => {
         mockScope = nock('https://www.khanacademy.org');
         cache.init(10000);
-        sinon.stub(renderSecret, 'matches', actual => actual === "sekret");
+        sinon.stub(renderSecret, 'matches', ( secret, callback) =>{
+          return callback(null, secret === "sekret");
+        });
         debugLoggingSpy = sinon.spy(logging, "debug");
         errorLoggingSpy = sinon.spy(logging, "error");
         graphiteLogStub = sinon.stub(graphiteUtil, "log");
@@ -365,7 +367,9 @@ describe('API endpoint /flush', () => {
     beforeEach(() => {
         mockScope = nock('https://www.khanacademy.org');
         cache.init(10000);
-        sinon.stub(renderSecret, 'matches', actual => actual === "sekret");
+        sinon.stub(renderSecret, 'matches', ( secret, callback) =>{
+          return callback(null, secret === "sekret");
+        });
     });
 
     afterEach(() => {
@@ -406,4 +410,3 @@ describe('API endpoint /flush', () => {
         ).end(done);
     });
 });
-

--- a/src/server_test.js
+++ b/src/server_test.js
@@ -91,7 +91,7 @@ describe('API endpoint /render', () => {
     beforeEach(() => {
         mockScope = nock('https://www.khanacademy.org');
         cache.init(10000);
-        sinon.stub(renderSecret, 'matches', ( secret, callback) =>{
+        sinon.stub(renderSecret, 'matches', ( secret, callback) => {
           return callback(null, secret === "sekret");
         });
         debugLoggingSpy = sinon.spy(logging, "debug");
@@ -367,7 +367,7 @@ describe('API endpoint /flush', () => {
     beforeEach(() => {
         mockScope = nock('https://www.khanacademy.org');
         cache.init(10000);
-        sinon.stub(renderSecret, 'matches', ( secret, callback) =>{
+        sinon.stub(renderSecret, 'matches', ( secret, callback) => {
           return callback(null, secret === "sekret");
         });
     });


### PR DESCRIPTION
### Description of change
Currently, the `secret.matches` function is synchronous, which causes the server to lockup while it reads the secret file from the file system before it continues execution. I've introduced a change to make the `secret.matches` function asynchronous and updated tests to match the async function.
This change also consolidates secret checking into a middleware function that can be reused in any new functions that need secret checking.

### Tests output
https://gist.github.com/Phanatic/9a9a6113413e39a7cd796d110a28470d


### Server running with changes.

#####  1. Server running without a secret file.
*Client*
``` bash
curl -XPOST http://localhost:8080/flush;echo
{"error":"Missing or invalid secret"}
```

*Server*

``` bash
error: FATAL ERROR (Error: ENOENT: no such file or directory, open '/Users/phaniraj/Documents/github/ka/react-render-server/secret'): You must create a file:
error:     /Users/phaniraj/Documents/github/ka/react-render-server/secret
error: Its contents should be the secret-string at
error:     https://phabricator.khanacademy.org/K121
info: POST /flush 400 7ms
Error: Missing or invalid secret
    at renderSecret.matches (/Users/phaniraj/Documents/github/ka/react-render-server/src/server.js:115:20)
    at get (/Users/phaniraj/Documents/github/ka/react-render-server/src/secret.js:49:16)
    at ReadFileContext.fs.readFile [as callback] (/Users/phaniraj/Documents/github/ka/react-render-server/src/secret.js:33:14)
    at FSReqWrap.readFileAfterOpen [as oncomplete] (fs.js:365:13)
```
##### 2. Call `/render` without a secret.

*Client*
``` bash
curl -XPOST http://localhost:8080/render;echo
{"error":"Missing or invalid secret"}
```

*Server*
``` bash
info: react-render-server running at http://:::8080
info: POST /render 400 9ms
```


##### 3. Call `/flush` without a secret.

*Client*

 ``` bash
curl -XPOST http://localhost:8080/flush;echo
{"error":"Missing or invalid secret"}
```

*Server*

``` bash
info: POST /flush 400 1ms
```