### PR TITLE
Only install production depedencies to run the application in the Docker Container

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -71,7 +71,7 @@ COPY . /app/
 # as well.
 # This command will also cat the npm-debug.log file after the
 # build, if it exists.
-RUN npm install --unsafe-perm || \
+RUN npm install --unsafe-perm --production|| \
   ((if [ -f npm-debug.log ]; then \
       cat npm-debug.log; \
     fi) && false)


### PR DESCRIPTION
### Description.
Added the `--production` flag to `npm install` to not install dev dependencies in the Docker Image.

####  Descrption of `--production` flag.
From [here](https://docs.npmjs.com/cli/install)

``` 
By default, npm install will install all modules listed as dependencies in package.json.

With the --production flag (or when the NODE_ENV environment variable is set to production),
 npm will not install modules listed in devDependencies.
```
#### With `--production` 

``` bash
du -sh node_modules/
 56M	node_modules/
```

#### Without `--production` 

``` bash
du -sh node_modules/
 82M	node_modules/
```

A saving of 26 MB  😄 