### PR TITLE
[WEB-994] Ensure globals set before scripts loaded

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -114,6 +114,7 @@ const render = async function(
     // and configure it accordingly.
     const context = createRenderContext(
         globals ? globals["location"] : "http://www.khanacademy.org",
+        globals,
         jsPackages,
         entryPointUrl,
         requestStats);
@@ -123,16 +124,6 @@ const render = async function(
     const renderProfile = profile.start("rendering " + entryPointUrl);
 
     try {
-        // Make sure the require globals are made available to the VM context.
-        if (globals) {
-            Object.keys(globals).forEach(key => {
-                // Location is a special case.
-                if (key !== 'location') {
-                    context.window[key] = globals[key];
-                }
-            });
-        }
-
         // If Apollo is required, get it configured on the context.
         if (context.window.ApolloNetwork) {
             configureApolloNetwork(context.window);


### PR DESCRIPTION
Summary:
This makes sure that global variables like `REACT_SSR` are set before
any script files are loaded that might make decisions based on such
values.

Test Plan:
`npm test`
Run this version of the server against webapp to check it all still works