### PR TITLE
Add flow types to render.js

### DIFF
--- a/flow-typed/custom/apollo-cache-inmemory.js
+++ b/flow-typed/custom/apollo-cache-inmemory.js
@@ -1,0 +1,25 @@
+// flow-typed signature: 1d91079d6f9a7cc4435ad74fd7a02f81
+// flow-typed version: <<STUB>>/apollo-cache-inmemory_v1.3.0/flow_v0.108.0
+import {ApolloCache} from "apollo-client";
+import type { StoreValue } from 'apollo-utilities';
+
+declare type apollocacheinmemory$StoreObject = {
+    __typename?: string;
+    [storeFieldKey: string]: StoreValue;
+}
+
+declare type apollocacheinmemory$NormalizedCacheObject = {
+    [dataId: string]: apollocacheinmemory$StoreObject;
+}
+
+declare class apollocacheinmemory$InMemoryCache extends ApolloCache<apollocacheinmemory$NormalizedCacheObject> {
+    constructor(): this;
+}
+
+declare module 'apollo-cache-inmemory' {
+    declare export type NormalizedCacheObject = apollocacheinmemory$NormalizedCacheObject;
+
+    declare module.exports: {
+        InMemoryCache: typeof apollocacheinmemory$InMemoryCache
+    };
+}

--- a/flow-typed/custom/argparse.js
+++ b/flow-typed/custom/argparse.js
@@ -1,0 +1,152 @@
+// flow-typed signature: 7e5c18bf3f1536f28836db5f0f0b8821
+// flow-typed version: <<STUB>>/argparse_v1.0.10/flow_v0.108.0
+
+declare class argparse$ArgumentParser mixins argparse$ArgumentGroup {
+    constructor(options?: argparse$ArgumentParserOptions): this;
+    addSubparsers(options?: argparse$SubparserOptions): argparse$SubParser;
+    parseArgs<TArgs>(args?: string[], ns?: argparse$Namespace | {[key: string]: mixed}): TArgs;
+    printUsage(): void;
+    printHelp(): void;
+    formatUsage(): string;
+    formatHelp(): string;
+    parseKnownArgs(args?: string[], ns?: argparse$Namespace | {[key: string]: mixed}): any[];
+    convertArgLineToArg(argLine: string): string[];
+    exit(status: number, message: string): void;
+    error(err: string | Error): void;
+}
+
+declare class argparse$Namespace {
+    constructor(options: {[key: string]: any}): this;
+    get<K: $Keys<this>, D: any>(key: K, defaultValue?: D): $ElementType<this, K> | D;
+    isset(key: $Keys<this>): boolean;
+    set<K: $Keys<this>>(key: K, value: $ElementType<this, K>): this;
+    set<K: string, V: any>(key: K, value: V): this & {[key: K]: V, ...};
+    set<K: {[key: string]: any}>(obj: K): this & K;
+    unset<K: $Keys<this>, D: any>(key: K, defaultValue?: D): $ElementType<this, K> | D;
+}
+
+declare class argparse$SubParser {
+    addParser(name: string, options?: argparse$SubArgumentParserOptions): argparse$ArgumentParser;
+}
+
+declare class argparse$ArgumentGroup {
+    addArgument(args: string[] | string, options?: argparse$ArgumentOptions): void;
+    addArgumentGroup(options?: argparse$ArgumentGroupOptions): argparse$ArgumentGroup;
+    addMutuallyExclusiveGroup(options?: {required: boolean,...}): argparse$ArgumentGroup;
+    setDefaults(options?: {...}): void;
+    getDefault(dest: string): any;
+}
+
+declare type argparse$SubparserOptions = {
+    title?: string,
+    description?: string,
+    prog?: string,
+    parserClass?: {
+        new (): any,...
+    },
+    action?: string,
+    dest?: string,
+    help?: string,
+    metavar?: string,
+}
+
+declare type argparse$SubArgumentParserOptions = {
+    aliases?: string[],
+    help?: string,
+    ...
+} & argparse$ArgumentParserOptions;
+
+declare type argparse$ArgumentParserOptions = {
+    description?: string,
+    epilog?: string,
+    addHelp?: boolean,
+    argumentDefault?: any,
+    parents?: argparse$ArgumentParser[],
+    prefixChars?: string,
+    formatterClass?: {
+        new (): argparse$HelpFormatter | argparse$ArgumentDefaultsHelpFormatter | argparse$RawDescriptionHelpFormatter | argparse$RawTextHelpFormatter,
+        ...
+    },
+    prog?: string,
+    usage?: string,
+    version?: string,
+    debug?: boolean,
+}
+
+declare type argparse$ArgumentGroupOptions = {
+    prefixChars?: string,
+    argumentDefault?: any,
+    title?: string,
+    description?: string,
+}
+
+declare class argparse$Action  {
+    dest: string;
+    constructor(options: argparse$ActionConstructorOptions): this;
+    call(
+        parser: ArgumentParser,
+        namespace: Namespace,
+        values: string | string[],
+        optionString: string | null,
+    ): void;
+}
+
+declare type argparse$ActionConstructorOptions = number & {
+    _: "ActionConstructorOptions",
+    ...
+};
+
+declare class argparse$HelpFormatter  {}
+declare class argparse$ArgumentDefaultsHelpFormatter {}
+declare class argparse$RawDescriptionHelpFormatter  {}
+declare class argparse$RawTextHelpFormatter  {}
+declare type argparse$ArgumentOptions = {
+    action?: string | {
+        new (options: argparse$ActionConstructorOptions): Action,
+        ...
+    },
+    optionStrings?: string[],
+    dest?: string,
+    nargs?: string | number,
+    constant?: any,
+    defaultValue?: any,
+    type?: string | Function,
+    choices?: string | string[],
+    required?: boolean,
+    help?: string,
+    metavar?: string,
+}
+
+declare type argparse$Const = {
+    +EOL: string,
+    +SUPPRESS: string,
+    +OPTIONAL: string,
+    +ZERO_OR_MORE: string,
+    +ONE_OR_MORE: string,
+    +PARSER: string,
+    +REMAINDER: string,
+    +_UNRECOGNIZED_ARGS_ATTR: string
+};
+
+declare module 'argparse' {
+    declare export type SubParser = argparse$SubParse;
+    declare export type SubparserOptions = argparse$SubparserOptions;
+    declare export type SubArgumentParserOptions = argparse$SubArgumentParserOptions;
+    declare export type ArgumentParserOptions = argparse$ArgumentParserOptions;
+    declare export type ArgumentGroup = argparse$ArgumentGroup;
+    declare export type ArgumentGroupOptions = argparse$ArgumentGroupOptions;
+    declare export type ArgumentOptions = argparse$ArgumentOptions;
+    declare export type ActionConstructorOptions = argparse$ActionConstructorOptions;
+
+    declare module.exports: {
+        ArgumentParser: typeof argparse$ArgumentParser,
+        Namespace: typeof argparse$Namespace,
+        Action: typeof argparse$Action,
+        HelpFormatter: typeof argparse$HelpFormatter,
+        Const: argparse$Const,
+
+        ArgumentDefaultsHelpFormatter: typeof argparse$ArgumentDefaultsHelpFormatter,
+        RawDescriptionHelpFormatter: typeof argparse$RawDescriptionHelpFormatter,
+        RawTextHelpFormatter: typeof argparse$RawTextHelpFormatter
+    };
+}

--- a/src/arguments.js
+++ b/src/arguments.js
@@ -6,12 +6,20 @@ import argparse from "argparse";
 
 import packageInfo from "../package.json";
 
-import type {LogLevel, IProvideArguments} from "./types.js";
+import type {LogLevel, PackageJson, IProvideArguments} from "./types.js";
+
+type RawParsedArgs = {
+    log_level: LogLevel,
+    dev: boolean,
+    port: number,
+};
+
+const packageInfoJson: PackageJson = packageInfo;
 
 const parser = new argparse.ArgumentParser({
-    version: packageInfo.version,
+    version: packageInfoJson.version,
     addHelp: true,
-    description: packageInfo.description,
+    description: packageInfoJson.description,
 });
 parser.addArgument(["-p", "--port"], {
     type: "int",
@@ -30,8 +38,8 @@ parser.addArgument(["--log-level"], {
 
 // We only want to parse the args if we're running inside our main app.
 // Could be src/main.js or dist/main.js.
-const args = process.argv[1].endsWith("/main.js")
-    ? parser.parseArgs()
+const args: RawParsedArgs = process.argv[1].endsWith("/main.js")
+    ? parser.parseArgs<RawParsedArgs>()
     : {
           // Some defaults for tests and the like.
           log_level: "debug",
@@ -43,9 +51,9 @@ const args = process.argv[1].endsWith("/main.js")
  * Wrapper class with accessors that can be overridden in testing.
  */
 class ArgumentProvider implements IProvideArguments {
-    _args: any;
+    _args: RawParsedArgs;
 
-    constructor(args: any) {
+    constructor(args: RawParsedArgs) {
         this._args = args;
     }
 

--- a/src/configure-apollo-network.js
+++ b/src/configure-apollo-network.js
@@ -19,18 +19,19 @@ import type {DOMWindow} from "jsdom";
 import type {NormalizedCacheObject} from "apollo-cache-inmemory";
 import type {ApolloClient, ApolloCache, ApolloLink} from "apollo-client";
 
-type ApolloNetworkConfiguration = {
+export type ApolloNetworkConfiguration = {
     timeout?: number,
     url?: string,
     headers?: any,
 };
 
-type ApolloGlobals = {
+export type ApolloGlobals = {
     +ApolloClientModule: typeof ApolloClientModule,
     +ApolloNetworkLink: ApolloLink,
     +ApolloCache: ApolloCache<NormalizedCacheObject>,
-    +ApolloNetwork: ApolloNetworkConfiguration,
 };
+
+export type ApolloClientInstance = ApolloClient<NormalizedCacheObject>;
 
 const BAD_URL = "BAD_URL";
 
@@ -42,71 +43,8 @@ const timeout = async (timeout: number, errorMsg: string): Promise<void> => {
     });
 };
 
-/**
- * Get the Apollo netowrk configuration.
- *
- * This runs both inside and outside the render JSDOM VM.
- */
-const getApolloConfiguration = (
-    contextWindow?: DOMWindow,
-): ?ApolloNetworkConfiguration => {
-    return ((contextWindow || global).ApolloNetwork: any);
-};
-
-/**
- * Build Apollo configuration info from global data.
- *
- * This runs inside the render JSDOM VM.
- */
-const getApolloGlobals = (): ?ApolloGlobals => {
-    const apolloNetworkConfig: ?ApolloNetworkConfiguration = getApolloConfiguration();
-
-    if (apolloNetworkConfig == null) {
-        return null;
-    }
-
-    return {
-        ApolloNetwork: (apolloNetworkConfig: ApolloNetworkConfiguration),
-        ApolloClientModule: global.ApolloClient,
-        ApolloNetworkLink: global.ApolloNetworkLink,
-        ApolloCache: global.ApolloCache,
-    };
-};
-
-/**
- * Get an instance of ApolloClient.
- *
- * This runs inside the render JSDOM VM. We know all the types because we set
- * this up.
- */
-export const getApolloClient = (): ?ApolloClient<NormalizedCacheObject> => {
-    const apolloGlobals = getApolloGlobals();
-
-    if (apolloGlobals == null) {
-        // For rendering things that have no Apollo-centric logic, we
-        // don't have a client.
-        return null;
-    }
-
-    const {ApolloClientModule, ApolloNetworkLink, ApolloCache} = apolloGlobals;
-
-    // If network details were provided for Apollo then we go about
-    // wrapping the element in an Apollo provider (which will
-    // collect the data requirements of the child components and
-    // send off a network request to a GraphQL endpoint).
-
-    // Build an Apollo client. This is responsible for making the
-    // network requests to the GraphQL endpoint and bringing back
-    // the data.
-    return new ApolloClientModule.ApolloClient<NormalizedCacheObject>({
-        ssrMode: true,
-        link: ApolloNetworkLink,
-        cache: ApolloCache,
-    });
-};
-
 export default function configureApolloNetwork(contextWindow: DOMWindow): void {
-    const ApolloNetwork = getApolloConfiguration(contextWindow);
+    const ApolloNetwork: ?ApolloNetworkConfiguration = (contextWindow.ApolloNetwork: any);
     if (ApolloNetwork == null) {
         return;
     }
@@ -134,30 +72,43 @@ export default function configureApolloNetwork(contextWindow: DOMWindow): void {
         return result;
     };
 
+    const apolloLink = createHttpLink({
+        // HACK(briang): If you give the uri undefined, it will call
+        // fetch("/graphql") but we want to ensure that an undefined URL
+        // will fail the request.
+        uri: ApolloNetwork.url || BAD_URL,
+        fetch: handleNetworkFetch,
+        headers: ApolloNetwork.headers,
+    });
+
     /**
-     * We attach these things to the context DOMWindow so that when running
-     * inside the VM, our code can retrieve them and operate upon them.
+     * Build all the configuration into an object.
+     *
+     * We do this so that it is strongly typed against the type that the
+     * receiving code uses; helping us verify we're setting things up the
+     * way the consumer will expect.
      */
-    Object.assign(contextWindow, {
+    const apolloGlobals: ApolloGlobals = {
         // We need to use the server-side Node.js version of
         // apollo-client (the ones we use on the main site
         // don't include the server-side rendering logic).
-        ApolloClient: ApolloClientModule,
+        ApolloClientModule: ApolloClientModule,
 
         // Additionally, we need to build a request mechanism for actually
         // making a network request to our GraphQL endpoint. We use the
         // node-fetch module for making this request. This logic
         // should be very similar to the logic held in apollo-wrapper.jsx.
-
-        ApolloNetworkLink: createHttpLink({
-            // HACK(briang): If you give the uri undefined, it will call
-            // fetch("/graphql") but we want to ensure that an undefined URL
-            // will fail the request.
-            uri: ApolloNetwork.url || BAD_URL,
-            fetch: handleNetworkFetch,
-            headers: ApolloNetwork.headers,
-        }),
+        // NOTE(somewhatabstract): We have to cast to any here since the type
+        // of ApolloLink exported from apollo-link-http and the one exported
+        // from apollo-client aren't see as the same type by flow (annoying).
+        ApolloNetworkLink: (apolloLink: any),
 
         ApolloCache: new InMemoryCache(),
-    });
+    };
+
+    /**
+     * We attach these things to the context DOMWindow so that when running
+     * inside the VM, our code can retrieve them and operate upon them.
+     */
+    Object.assign(contextWindow, apolloGlobals);
 }

--- a/src/configure-apollo-network.js
+++ b/src/configure-apollo-network.js
@@ -86,8 +86,10 @@ export default function configureApolloNetwork(
      */
     const apolloGlobals: ApolloGlobals = {
         // We need to use the server-side Node.js version of
-        // apollo-client (the ones we use on the main site
-        // don't include the server-side rendering logic).
+        // apollo-client module import rather than the "browser" version.
+        // So we provide the Node-imported version to our render context that
+        // would otherwise be importing code inside of the JSDOM browser-like
+        // code.
         ApolloClientModule: ApolloClientModule,
 
         // Additionally, we need to build a request mechanism for actually
@@ -96,7 +98,7 @@ export default function configureApolloNetwork(
         // should be very similar to the logic held in apollo-wrapper.jsx.
         // NOTE(somewhatabstract): We have to cast to any here since the type
         // of ApolloLink exported from apollo-link-http and the one exported
-        // from apollo-client aren't see as the same type by flow (annoying).
+        // from apollo-client aren't seen as the same type by flow (annoying).
         ApolloNetworkLink: (apolloLink: any),
 
         ApolloCache: new InMemoryCache(),

--- a/src/configure-apollo-network.js
+++ b/src/configure-apollo-network.js
@@ -10,17 +10,26 @@
  * Requests will automatically timeout after 1000ms, unless another
  * timeout is provided via a 'timeout' property.
  */
-import * as ApolloClient from "apollo-client";
+import * as ApolloClientModule from "apollo-client";
 import {InMemoryCache} from "apollo-cache-inmemory";
 import {createHttpLink} from "apollo-link-http";
 import fetch from "node-fetch";
 
 import type {DOMWindow} from "jsdom";
+import type {NormalizedCacheObject} from "apollo-cache-inmemory";
+import type {ApolloClient, ApolloCache, ApolloLink} from "apollo-client";
 
 type ApolloNetworkConfiguration = {
     timeout?: number,
     url?: string,
     headers?: any,
+};
+
+type ApolloGlobals = {
+    +ApolloClientModule: typeof ApolloClientModule,
+    +ApolloNetworkLink: ApolloLink,
+    +ApolloCache: ApolloCache<NormalizedCacheObject>,
+    +ApolloNetwork: ApolloNetworkConfiguration,
 };
 
 const BAD_URL = "BAD_URL";
@@ -33,15 +42,76 @@ const timeout = async (timeout: number, errorMsg: string): Promise<void> => {
     });
 };
 
+/**
+ * Get the Apollo netowrk configuration.
+ *
+ * This runs both inside and outside the render JSDOM VM.
+ */
+const getApolloConfiguration = (
+    contextWindow?: DOMWindow,
+): ?ApolloNetworkConfiguration => {
+    return ((contextWindow || global).ApolloNetwork: any);
+};
+
+/**
+ * Build Apollo configuration info from global data.
+ *
+ * This runs inside the render JSDOM VM.
+ */
+const getApolloGlobals = (): ?ApolloGlobals => {
+    const apolloNetworkConfig: ?ApolloNetworkConfiguration = getApolloConfiguration();
+
+    if (apolloNetworkConfig == null) {
+        return null;
+    }
+
+    return {
+        ApolloNetwork: (apolloNetworkConfig: ApolloNetworkConfiguration),
+        ApolloClientModule: global.ApolloClient,
+        ApolloNetworkLink: global.ApolloNetworkLink,
+        ApolloCache: global.ApolloCache,
+    };
+};
+
+/**
+ * Get an instance of ApolloClient.
+ *
+ * This runs inside the render JSDOM VM. We know all the types because we set
+ * this up.
+ */
+export const getApolloClient = (): ?ApolloClient<NormalizedCacheObject> => {
+    const apolloGlobals = getApolloGlobals();
+
+    if (apolloGlobals == null) {
+        // For rendering things that have no Apollo-centric logic, we
+        // don't have a client.
+        return null;
+    }
+
+    const {ApolloClientModule, ApolloNetworkLink, ApolloCache} = apolloGlobals;
+
+    // If network details were provided for Apollo then we go about
+    // wrapping the element in an Apollo provider (which will
+    // collect the data requirements of the child components and
+    // send off a network request to a GraphQL endpoint).
+
+    // Build an Apollo client. This is responsible for making the
+    // network requests to the GraphQL endpoint and bringing back
+    // the data.
+    return new ApolloClientModule.ApolloClient<NormalizedCacheObject>({
+        ssrMode: true,
+        link: ApolloNetworkLink,
+        cache: ApolloCache,
+    });
+};
+
 export default function configureApolloNetwork(contextWindow: DOMWindow): void {
-    const apolloNetworkConfiguration: ApolloNetworkConfiguration = (contextWindow[
-        "ApolloNetwork"
-    ]: any);
-    if (apolloNetworkConfiguration == null) {
+    const ApolloNetwork = getApolloConfiguration(contextWindow);
+    if (ApolloNetwork == null) {
         return;
     }
 
-    const handleNetworkFetch = async (url, params) => {
+    const handleNetworkFetch = async (url: string, params: any) => {
         if (!url || url === BAD_URL) {
             throw new Error("ApolloNetwork must have a valid url.");
         }
@@ -51,7 +121,7 @@ export default function configureApolloNetwork(contextWindow: DOMWindow): void {
             // After a specified timeout we abort the request if
             // it's still on-going.
             timeout(
-                apolloNetworkConfiguration.timeout || 1000,
+                ApolloNetwork.timeout || 1000,
                 "Server response exceeded timeout.",
             ),
         ]);
@@ -64,11 +134,15 @@ export default function configureApolloNetwork(contextWindow: DOMWindow): void {
         return result;
     };
 
+    /**
+     * We attach these things to the context DOMWindow so that when running
+     * inside the VM, our code can retrieve them and operate upon them.
+     */
     Object.assign(contextWindow, {
         // We need to use the server-side Node.js version of
         // apollo-client (the ones we use on the main site
         // don't include the server-side rendering logic).
-        ApolloClient: ApolloClient,
+        ApolloClient: ApolloClientModule,
 
         // Additionally, we need to build a request mechanism for actually
         // making a network request to our GraphQL endpoint. We use the
@@ -79,9 +153,9 @@ export default function configureApolloNetwork(contextWindow: DOMWindow): void {
             // HACK(briang): If you give the uri undefined, it will call
             // fetch("/graphql") but we want to ensure that an undefined URL
             // will fail the request.
-            uri: apolloNetworkConfiguration.url || BAD_URL,
+            uri: ApolloNetwork.url || BAD_URL,
             fetch: handleNetworkFetch,
-            headers: apolloNetworkConfiguration.headers,
+            headers: ApolloNetwork.headers,
         }),
 
         ApolloCache: new InMemoryCache(),

--- a/src/render.js
+++ b/src/render.js
@@ -182,7 +182,15 @@ export default async function render(
 
     try {
         // If Apollo is required, get it configured on the context.
-        configureApolloNetwork(context.window);
+        const apolloNetwork: ?ApolloNetworkConfiguration = (context.window
+            .ApolloNetwork: any);
+        const apolloGlobals = configureApolloNetwork(apolloNetwork);
+
+        /**
+         * We attach these things to the context window so that when running
+         * inside the VM, our code can retrieve them and operate upon them.
+         */
+        Object.assign(context.window, apolloGlobals);
 
         // Now that everything is setup, we can invoke our rendering.
         if (context.window.__rrs == null) {

--- a/src/render_apollo_test.js
+++ b/src/render_apollo_test.js
@@ -1,4 +1,6 @@
 // @noflow
+import render from "./render.js";
+
 const fs = require("fs");
 
 const chai = require("chai");
@@ -6,8 +8,6 @@ const chai = require("chai");
 const {assert} = chai;
 
 const nock = require("nock");
-
-const render = require("./render.js");
 
 describe("render apollo", () => {
     const loadPackages = (packageNames) =>

--- a/src/render_test.js
+++ b/src/render_test.js
@@ -1,4 +1,6 @@
 // @noflow
+import render from "./render.js";
+
 const fs = require("fs");
 const jsdom = require("jsdom");
 
@@ -7,8 +9,6 @@ const chai = require("chai");
 const {assert} = chai;
 
 const sinon = require("sinon");
-
-const render = require("./render.js");
 
 describe("render", () => {
     const loadPackages = (packageNames) =>

--- a/src/server.js
+++ b/src/server.js
@@ -208,7 +208,7 @@ app.post("/render", checkSecret, async (req: $Request, res: $Response) => {
             packages,
             props,
             globals,
-            res.locals.requestStats,
+            (res.locals.requestStats: any),
         );
 
         // We store the updated request-stats in renderedState

--- a/src/types.js
+++ b/src/types.js
@@ -1,9 +1,5 @@
 // @flow
-import * as ApolloClient from "apollo-client";
-
 import type {JSDOM} from "jsdom";
-import type {ApolloCache} from "apollo-client";
-import type {ApolloLink} from "apollo-link-http";
 
 import type {
     NpmLogLevels,
@@ -46,21 +42,25 @@ export type RequestStats = {
     createdVmContext: boolean,
 };
 
-type ApolloNetworkConfiguration = {
-    timeout?: number,
-    url?: string,
-    headers?: any,
-};
-
 export interface RenderContext extends JSDOM {
     close: () => void;
-    run: (fnOrText: Function | string, options?: vm$ScriptOptions) => mixed;
-
-    ApolloClient?: typeof ApolloClient;
-    ApolloNetworkLink?: ApolloLink;
-    ApolloCache?: ApolloCache<mixed>;
-    ApolloNetwork?: ApolloNetworkConfiguration;
+    run: <TReturns>(
+        fnOrText: (() => TReturns) | string,
+        options?: vm$ScriptOptions,
+    ) => TReturns;
 }
+
+export type RenderResult = {
+    data?: any,
+    requestStats?: RequestStats,
+    ...
+};
+
+export type PackageJson = {
+    version: string,
+    description: string,
+    ...
+};
 
 /* eslint-disable flowtype/no-dupe-keys */
 /**


### PR DESCRIPTION
This adds flow types to `render.js` as well as refactoring some code to tidy up how we do things.

Namely:

- Change `configureApolloClient` so that it doesn't need to know how it all gets used
- Add libdef for `argparse`
- Add libdef for `apollo-cache-inmemory`
- Add more strong types to things where we can and increase flow coverage

Before this change:

```shell
npx flow batch-coverage src

Coverage results from 11 file(s):

/Users/jeffyates/khan/react-render-server/src/types.js: 100.00% (18 of 18 expressions)
/Users/jeffyates/khan/react-render-server/src/server.js: 88.17% (395 of 448 expressions)
/Users/jeffyates/khan/react-render-server/src/secret_test.js: 77.01% (134 of 174 expressions)
/Users/jeffyates/khan/react-render-server/src/secret.js: 100.00% (93 of 93 expressions)
/Users/jeffyates/khan/react-render-server/src/profile.js: 100.00% (38 of 38 expressions)
/Users/jeffyates/khan/react-render-server/src/main.js: 84.48% (98 of 116 expressions)
/Users/jeffyates/khan/react-render-server/src/logging.js: 86.89% (179 of 206 expressions)
/Users/jeffyates/khan/react-render-server/src/fetch_package.js: 78.23% (97 of 124 expressions)
/Users/jeffyates/khan/react-render-server/src/create-render-context.js: 86.29% (321 of 372 expressions)
/Users/jeffyates/khan/react-render-server/src/configure-apollo-network.js: 90.11% (82 of 91 expressions)
/Users/jeffyates/khan/react-render-server/src/arguments.js: 56.79% (46 of 81 expressions)

-----------------------------------
Aggregate coverage statistics
-----------------------------------
Files                : 11
Expressions          :
  Covered            : 1501
  Total              : 1761
  Covered Percentage : 85.24%
```

After this change:

```shell
npx flow batch-coverage src

Coverage results from 12 file(s):

/Users/jeffyates/khan/react-render-server/src/types.js: 100.00% (17 of 17 expressions)
/Users/jeffyates/khan/react-render-server/src/server.js: 90.42% (406 of 449 expressions)
/Users/jeffyates/khan/react-render-server/src/secret_test.js: 77.01% (134 of 174 expressions)
/Users/jeffyates/khan/react-render-server/src/secret.js: 100.00% (93 of 93 expressions)
/Users/jeffyates/khan/react-render-server/src/render.js: 83.82% (145 of 173 expressions)
/Users/jeffyates/khan/react-render-server/src/profile.js: 100.00% (38 of 38 expressions)
/Users/jeffyates/khan/react-render-server/src/main.js: 84.48% (98 of 116 expressions)
/Users/jeffyates/khan/react-render-server/src/logging.js: 86.89% (179 of 206 expressions)
/Users/jeffyates/khan/react-render-server/src/fetch_package.js: 78.23% (97 of 124 expressions)
/Users/jeffyates/khan/react-render-server/src/create-render-context.js: 87.10% (324 of 372 expressions)
/Users/jeffyates/khan/react-render-server/src/configure-apollo-network.js: 96.88% (93 of 96 expressions)
/Users/jeffyates/khan/react-render-server/src/arguments.js: 97.65% (83 of 85 expressions)

-----------------------------------
Aggregate coverage statistics
-----------------------------------
Files                : 12
Expressions          :
  Covered            : 1707
  Total              : 1943
  Covered Percentage : 87.85%
```