### PR TITLE
Add flow types to the rest of the files

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -57,6 +57,7 @@
                 "ignorePackages": true
             }
         ],
+        "import/no-commonjs": "error",
         "promise/always-return": "error",
         "promise/no-return-wrap": "error",
         "promise/param-names": "error",

--- a/.eslintrc
+++ b/.eslintrc
@@ -12,13 +12,13 @@
     "settings": {
         "eslint-plugin-disable": {
           "paths": {
-            "react": ["src/*.js"]
+            "react": ["./*.js", "src/*.js"]
           }
         }
     },
     "overrides": [
         {
-            "files": ["src/*.js"],
+            "files": ["./*.js", "src/*.js"],
             "settings": {
                 "flowtype": {
                     "onlyFilesWithFlowAnnotation": false

--- a/app.js
+++ b/app.js
@@ -1,4 +1,5 @@
+// @noflow
 // This is only needed when deploying to Appengine Standard
 // (app.js is the hard-coded entrypoint for appengine-standard apps).
-// eslint-disable-next-line import/no-unassigned-import
+// eslint-disable-next-line import/no-unassigned-import, import/no-commonjs
 require("./dist/main.js");

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "deploy": "./deploy.sh",
     "deploy:docker": "DOCKER=1 ./deploy.sh",
     "set_default": "./set_default.sh",
-    "lint": "flow && eslint --config .eslintrc src",
+    "lint": "flow && eslint --config .eslintrc ./*.js src",
     "prettyquick": "pretty-quick",
     "build": "npm run clean && babel src --out-dir dist --source-maps --ignore src/testdata",
     "postinstall": "npm run build"

--- a/src/create-render-context.js
+++ b/src/create-render-context.js
@@ -264,7 +264,7 @@ export default function createRenderContextWithStats(
     locationUrl: string,
     globals: Globals,
     jsPackages: Array<any>,
-    requestStats: RequestStats,
+    requestStats?: RequestStats,
 ): RenderContext {
     const vmConstructionProfile = profile.start(
         `building VM ${(globals && `for ${globals["location"]}`) || ""}`,

--- a/src/fetch_package_test.js
+++ b/src/fetch_package_test.js
@@ -1,9 +1,8 @@
-// @noflow
+// @flow
 
 import fetchPackage from "./fetch_package.js";
-
-const assert = require("chai").assert;
-const nock = require("nock");
+import {assert} from "chai";
+import nock from "nock";
 
 describe("fetchPackage", () => {
     let mockScope;

--- a/src/render.js
+++ b/src/render.js
@@ -163,7 +163,7 @@ export default async function render(
     jsPackages: Array<JavaScriptPackage>,
     props: mixed,
     globals: Globals,
-    requestStats: RequestStats,
+    requestStats?: RequestStats,
 ) {
     // Here we get the existing VM context for this request or create a new one
     // and configure it accordingly.

--- a/src/render_apollo_test.js
+++ b/src/render_apollo_test.js
@@ -1,13 +1,8 @@
-// @noflow
+// @flow
+import fs from "fs";
+import {assert} from "chai";
 import render from "./render.js";
-
-const fs = require("fs");
-
-const chai = require("chai");
-
-const {assert} = chai;
-
-const nock = require("nock");
+import nock from "nock";
 
 describe("render apollo", () => {
     const loadPackages = (packageNames) =>
@@ -93,6 +88,7 @@ describe("render apollo", () => {
             packages,
             {},
             {
+                location: "https://www.khanacademy.org",
                 ApolloNetwork: {
                     url: "https://www.ka.org/graphql",
                 },
@@ -118,6 +114,7 @@ describe("render apollo", () => {
             packages,
             {name: "Test Class 1"},
             {
+                location: "https://www.khanacademy.org",
                 ApolloNetwork: {
                     url: "https://www.ka.org/graphql",
                 },
@@ -155,6 +152,7 @@ describe("render apollo", () => {
             packages,
             {},
             {
+                location: "https://www.khanacademy.org",
                 ApolloNetwork: {
                     url: "https://www.ka.org/graphql",
                     headers: headers,
@@ -182,6 +180,7 @@ describe("render apollo", () => {
             packages,
             {},
             {
+                location: "https://www.khanacademy.org",
                 ApolloNetwork: {
                     url: "https://www.ka.org/graphql",
                 },
@@ -222,6 +221,7 @@ describe("render apollo", () => {
             packages,
             {},
             {
+                location: "https://www.khanacademy.org",
                 ApolloNetwork: {
                     url: "https://www.ka.org/graphql",
                 },
@@ -249,6 +249,7 @@ describe("render apollo", () => {
             packages,
             {},
             {
+                location: "https://www.khanacademy.org",
                 ApolloNetwork: {},
             },
         );
@@ -275,6 +276,7 @@ describe("render apollo", () => {
             packages,
             {},
             {
+                location: "https://www.khanacademy.org",
                 ApolloNetwork: {
                     url: "https://www.ka.org/graphql",
                 },
@@ -303,6 +305,7 @@ describe("render apollo", () => {
             packages,
             {},
             {
+                location: "https://www.khanacademy.org",
                 ApolloNetwork: {
                     url: "https://www.ka.org/graphql",
                 },
@@ -334,6 +337,7 @@ describe("render apollo", () => {
             packages,
             {},
             {
+                location: "https://www.khanacademy.org",
                 ApolloNetwork: {
                     url: "https://www.ka.org/graphql",
                 },
@@ -362,6 +366,7 @@ describe("render apollo", () => {
             packages,
             {},
             {
+                location: "https://www.khanacademy.org",
                 ApolloNetwork: {
                     url: "https://www.ka.org/graphql",
                 },
@@ -393,6 +398,7 @@ describe("render apollo", () => {
             packages,
             {},
             {
+                location: "https://www.khanacademy.org",
                 ApolloNetwork: {
                     url: "https://www.ka.org/graphql",
                     timeout: 100,

--- a/src/render_test.js
+++ b/src/render_test.js
@@ -1,14 +1,9 @@
-// @noflow
+// @flow
+import fs from "fs";
+import jsdom from "jsdom";
+import {assert} from "chai";
+import sinon from "sinon";
 import render from "./render.js";
-
-const fs = require("fs");
-const jsdom = require("jsdom");
-
-const chai = require("chai");
-
-const {assert} = chai;
-
-const sinon = require("sinon");
 
 describe("render", () => {
     const loadPackages = (packageNames) =>
@@ -25,7 +20,7 @@ describe("render", () => {
     });
 
     afterEach(() => {
-        jsdom.JSDOM.restore();
+        sinon.restore();
     });
 
     it("should perform basic render flow", async () => {
@@ -41,7 +36,9 @@ describe("render", () => {
         };
 
         // Act
-        const result = await render(packages, props);
+        const result = await render(packages, props, {
+            location: "https://example.com",
+        });
 
         // Assert
         assert.deepEqual(result, expectation);
@@ -68,7 +65,9 @@ describe("render", () => {
         };
 
         // Act
-        const result = await render(packages, props);
+        const result = await render(packages, props, {
+            location: "https://example.com",
+        });
 
         // Assert
         assert.deepEqual(result, expectation);
@@ -95,7 +94,9 @@ describe("render", () => {
         };
 
         // Act
-        const result = await render(packages, props);
+        const result = await render(packages, props, {
+            location: "https://example.com",
+        });
 
         // Assert
         assert.deepEqual(result, expectation);
@@ -104,10 +105,22 @@ describe("render", () => {
     it("should render the same thing for the same parameters", async () => {
         // Arrange
         const packages = loadPackages(["basic/entry.js"]);
-        const expectation = await render(packages, {name: "A NAME"});
+        const expectation = await render(
+            packages,
+            {name: "A NAME"},
+            {
+                location: "https://example.com",
+            },
+        );
 
         // Act
-        const result = await render(packages, {name: "A NAME"});
+        const result = await render(
+            packages,
+            {name: "A NAME"},
+            {
+                location: "https://example.com",
+            },
+        );
 
         // Assert
         assert.deepEqual(result, expectation);
@@ -116,10 +129,22 @@ describe("render", () => {
     it("should render the same thing differently with different props", async () => {
         // Arrange
         const packages = loadPackages(["basic/entry.js"]);
-        const expectation = await render(packages, {name: "A NAME"});
+        const expectation = await render(
+            packages,
+            {name: "A NAME"},
+            {
+                location: "https://example.com",
+            },
+        );
 
         // Act
-        const result = await render(packages, {name: "A DIFFERENT NAME"});
+        const result = await render(
+            packages,
+            {name: "A DIFFERENT NAME"},
+            {
+                location: "https://example.com",
+            },
+        );
 
         // Assert
         assert.notDeepEqual(result, expectation);
@@ -136,7 +161,14 @@ describe("render", () => {
 
         // Act
         // All we're testing for here is that this renders without crashing.
-        const underTest = async () => await render(packages, {name: "A NAME"});
+        const underTest = async () =>
+            await render(
+                packages,
+                {name: "A NAME"},
+                {
+                    location: "https://example.com",
+                },
+            );
 
         // Assert
         assert.doesNotThrow(underTest);

--- a/src/server.js
+++ b/src/server.js
@@ -251,4 +251,4 @@ app.get("/prime", (req: $Request, res: $Response) => {
     res.send("ok\n");
 });
 
-module.exports = app;
+export default app;

--- a/src/server_test.js
+++ b/src/server_test.js
@@ -1,15 +1,12 @@
-// @noflow
+// @flow
+import fs from "fs";
+import {assert} from "chai";
+import nock from "nock";
+import sinon from "sinon";
+import supertest from "supertest";
+import * as renderSecret from "./secret.js";
+import server from "./server.js";
 import logging from "./logging.js";
-
-const fs = require("fs");
-
-const assert = require("chai").assert;
-const nock = require("nock");
-const sinon = require("sinon");
-const supertest = require("supertest");
-
-const renderSecret = require("./secret.js");
-const server = require("./server.js");
 
 describe("API endpoint /_api/ping", () => {
     const agent = supertest.agent(server);


### PR DESCRIPTION
This adds flow types to the remaining test files and turns on `import/no-commonj` lint rule.

Also makes sure `app.js` is linted and other tweaks.