### PR TITLE
Use keepalive agent to maintain server connections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1561,6 +1561,26 @@
         "es6-promisify": "^5.0.0"
       }
     },
+    "agentkeepalive": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.0.2.tgz",
+      "integrity": "sha512-A5gSniD4xMCYtSD4ilUHpQRB9ZbNjtIPittKUv7bA0j0UCwbT3EJBUYLKPJ/dtmaXRYWI2mG4/O90xbi7oahNw==",
+      "requires": {
+        "debug": "^4.1.0",
+        "depd": "^1.1.2",
+        "humanize-ms": "^1.2.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
     "ajv": {
       "version": "6.10.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
@@ -5209,6 +5229,14 @@
       "requires": {
         "agent-base": "^4.3.0",
         "debug": "^3.1.0"
+      }
+    },
+    "humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
+      "requires": {
+        "ms": "^2.0.0"
       }
     },
     "iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@google-cloud/logging-winston": "^2.0.1",
     "@google-cloud/profiler": "^2.0.2",
     "@google-cloud/trace-agent": "^4.1.1",
+    "agentkeepalive": "^4.0.2",
     "apollo-cache-inmemory": "1.3.0",
     "apollo-client": "2.2.7",
     "apollo-link-http": "1.5.3",


### PR DESCRIPTION
This update adds the `keepaliveagent` dependency, allowing us to configure our `superagent` fetches to reuse sockets. This should enable us to to get a better download rate from Fastly when we demand a large number of files at once.

# Test plan

1. Tested in dev webapp that files are still downloading from webpack as we would want
2. TBD Deploy commit to GAE and then use testing utilities to send requests and verify things work against fastly; compare similar requests against the existing implementation to see if we notice any improvements in file retrieval.