### PR TITLE
Remove ulimit and cleaning from start command

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -25,11 +25,6 @@ VERSION=`git log -n1 --format="format:%H %ct" | perl -ne '$ENV{TZ} = "US/Pacific
 [ `git status -u -s | wc -c` -eq 0 ] \
     || die "You must commit your changes before deploying."
 
-# Ensure we're deploying from latest master
-git fetch origin
-[ `git rev-parse HEAD` = `git rev-parse origin/master` ] \
-    || die "You must deploy from latest origin/master."
-
 # Don't deploy if tests fail
 npm test
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/main.js",
   "scripts": {
     "clean": "rm -rf dist",
-    "start": "npm run build:noclean && node dist/main.js -p 8080 --log-level=debug",
+    "start": "node dist/main.js -p 8080 --log-level=debug",
     "serve_local": "npm run build && nodemon dist/main.js -- --dev",
     "test": "NODE_ENV=test mocha --exit --reporter spec 'src/*_test.js' --require @babel/register --require test_setup.js",
     "deploy": "./deploy.sh",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/main.js",
   "scripts": {
     "clean": "rm -rf dist",
-    "start": "ulimit -n 999999 || ulimit -n 2048; npm run build && node dist/main.js -p 8080 --log-level=debug",
+    "start": "npm run build:noclean && node dist/main.js -p 8080 --log-level=debug",
     "serve_local": "npm run build && nodemon dist/main.js -- --dev",
     "test": "NODE_ENV=test mocha --exit --reporter spec 'src/*_test.js' --require @babel/register --require test_setup.js",
     "deploy": "./deploy.sh",
@@ -13,7 +13,8 @@
     "set_default": "./set_default.sh",
     "lint": "flow && eslint --config .eslintrc ./*.js src",
     "prettyquick": "pretty-quick",
-    "build": "npm run clean && babel src --out-dir dist --source-maps --ignore src/testdata",
+    "build:noclean": "babel src --out-dir dist --source-maps --ignore src/testdata",
+    "build": "npm run clean && npm run build:noclean",
     "postinstall": "npm run build"
   },
   "repository": {


### PR DESCRIPTION
AppEngine standard [complains about ulimit usage](https://console.cloud.google.com/logs/viewer?project=khan-academy&minLogLevel=0&expandAll=false&timestamp=2019-10-30T22%3A57%3A13.016000000Z&customFacets&limitCustomFacetWidth=true&dateRangeStart=2019-10-30T21%3A57%3A13.275Z&dateRangeEnd=2019-10-30T22%3A57%3A13.275Z&interval=PT1H&resource=gae_app%2Fmodule_id%2Freact-render%2Fversion_id%2F191025-1142-cd9a8b41f82f&logName=projects%2Fkhan-academy%2Flogs%2Fstdout&logName=projects%2Fkhan-academy%2Flogs%2Fstderr&logName=projects%2Fkhan-academy%2Flogs%2Fappengine.googleapis.com%252Frequest_log&scrollTimestamp=2019-10-30T22%3A41%3A00.671247000Z&advancedFilter=resource.type%3D%22gae_app%22%0Aresource.labels.version_id%3D%22191025-1142-cd9a8b41f82f%22%0Aresource.labels.module_id%3D%22react-render%22%0Aresource.labels.zone%3D%22us12%22%0Aresource.labels.project_id%3D%22khan-academy%22%0Atimestamp%3D%222019-10-30T22%3A40%3A59.404689000Z%22%0AinsertId%3D%225dba117b00062cd1f412b01d%22) and [does not allow the rm command to be executed](https://console.cloud.google.com/logs/viewer?project=khan-academy&minLogLevel=0&expandAll=false&timestamp=2019-10-30T22%3A57%3A13.016000000Z&customFacets&limitCustomFacetWidth=true&dateRangeStart=2019-10-30T21%3A57%3A13.275Z&dateRangeEnd=2019-10-30T22%3A57%3A13.275Z&interval=PT1H&resource=gae_app%2Fmodule_id%2Freact-render%2Fversion_id%2F191025-1142-cd9a8b41f82f&logName=projects%2Fkhan-academy%2Flogs%2Fstdout&logName=projects%2Fkhan-academy%2Flogs%2Fstderr&logName=projects%2Fkhan-academy%2Flogs%2Fappengine.googleapis.com%252Frequest_log&scrollTimestamp=2019-10-30T22%3A41%3A00.721282000Z&advancedFilter=resource.type%3D%22gae_app%22%0Aresource.labels.project_id%3D%22khan-academy%22%0Aresource.labels.version_id%3D%22191025-1142-cd9a8b41f82f%22%0Aresource.labels.module_id%3D%22react-render%22%0Aresource.labels.zone%3D%22us12%22%0Atimestamp%3D%222019-10-30T22%3A41%3A00.719709000Z%22%0AinsertId%3D%225dba117c000afb5d0ce662f2%22); this causes errors when trying to run our app.

This also removes the `deploy.sh` check that we're only deploying the latest master. That check hinders us deploying changes early to test.

# Test Plan
I am deploying this commit right now and trying out the `_api/ping` and `_api/version` commands to see if they now work instead of 500-ing without a stack. I suspect these errors are the root of that issue, but if not, eliminating them should help track it down.