### PR TITLE
Address image load failures

### DIFF
--- a/src/create-render-context.js
+++ b/src/create-render-context.js
@@ -28,7 +28,6 @@ type RenderContextWithSize = {
 class CustomResourceLoader extends ResourceLoader {
     _active: boolean;
     _requestStats: ?RequestStats;
-    _cachedFakeImageResponse: ?Promise<Buffer>;
 
     /**
      * We will return EMPTY in cases where we just don't care about the file

--- a/src/create-render-context.js
+++ b/src/create-render-context.js
@@ -72,6 +72,11 @@ class CustomResourceLoader extends ResourceLoader {
         return promiseToBuffer;
     }
 
+    _isImage(url: string): boolean {
+        const ImageRegex = /^.*\.(jpe?g|png|gif)(?:\?.*)?/g;
+        return url.startsWith("data:image") || ImageRegex.test(url);
+    }
+
     fetch(url: string, options: FetchOptions): ?Promise<Buffer> {
         const isInlineData = url.startsWith("data:");
         const loggableUrl = isInlineData ? "inline data" : url;
@@ -104,13 +109,16 @@ class CustomResourceLoader extends ResourceLoader {
              * resolutions that are relying on this file. Instead, we resolve
              * as an empty string.
              */
-            return isInlineData
-                ? super.fetch("data:null", options)
-                : /**
-                   * This isn't ideal. Things expecting images are going to be
-                   * upset.
-                   */
-                  CustomResourceLoader.EMPTY;
+            return this._isImage(url)
+                ? super.fetch(
+                      /**
+                       * Shortest valid image:
+                       * https://stackoverflow.com/a/13139830/23234
+                       */
+                      "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7",
+                      options,
+                  )
+                : CustomResourceLoader.EMPTY;
         }
 
         // If this is a JavaScript request, then we want to do some things to

--- a/src/create-render-context.js
+++ b/src/create-render-context.js
@@ -180,8 +180,13 @@ const patchTimers = (): void => {
 const createVirtualConsole = () => {
     const virtualConsole = new VirtualConsole();
     virtualConsole.on("jsdomError", (e: Error) => {
+        if (e.message.indexOf("Could not load img") >= 0) {
+            // We know that images cannot load. We're deliberately blocking
+            // them.
+            return;
+        }
         // eslint-disable-next-line no-console
-        console.error(`JSDOM: ${e.name} ${e.message}\n${e.stack}`);
+        console.error(`JSDOM: ${e.stack}`);
     });
     virtualConsole.sendTo(console, {omitJSDOMErrors: true});
     return virtualConsole;


### PR DESCRIPTION
So, we have had a naïve solution to loading images during SSR, just returning an empty string. But an empty file is not a valid image, and so this can cause the page being rendered to output errors.

In addition, JSDOM incorrectly expects `abort` to be a call of request promises, but our empty results didn't have this method.

This update adds an `abort` noop to our `EMPTY` result, and a minimum viable `data:` url image that we can return as our fake image result. We rely on JSDOM to decode this for us, but sadly, it does so into a `Promise` that does not have `abort` and so we have to add our own noop to that too.