### PR TITLE
Use superagent-cache-plugin's new gutResponse param

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "node-fetch": "1.7.3",
     "nodemon": "^1.18.7",
     "superagent": "^5.1.0",
-    "superagent-cache-plugin": "^2.0.1",
+    "superagent-cache-plugin": "^2.1.0",
     "winston": "^3.2.1"
   },
   "devDependencies": {

--- a/src/fetch_package.js
+++ b/src/fetch_package.js
@@ -15,7 +15,6 @@
 import superagent from "superagent";
 import superagentCachePlugin from "superagent-cache-plugin";
 import cacheModule from "cache-service-cache-module";
-import {gutResponse} from "superagent-cache-plugin/utils.js";
 import Agent from "agentkeepalive";
 
 import args from "./arguments.js";
@@ -110,7 +109,7 @@ export default async function fetchPackage(
         return fetcher
             .use(superagentCache)
             .expiration(900)
-            .prune((response) => {
+            .prune((response, gutResponse) => {
                 /**
                  * We want to use our own `prune` method so that we can track
                  * what comes from cache versus what doesn't.


### PR DESCRIPTION
Hi there! I happened upon this repo's use of `superagent-cache-plugin` and noticed that you had to import `gutResponse` directly from the `utils` file for use in your `prune` callback. Having `gutResponse` available in that context makes sense, so I cut a new release of the plugin that exposes `gutResponse` to the `prune` callback so you don't have to import outside the public API.