### PR TITLE
WEB-1754 #"Land Change" #comment Put error information directly in log

### DIFF
--- a/src/server_test.js
+++ b/src/server_test.js
@@ -174,6 +174,9 @@ describe("API endpoint /render", function() {
             ],
             props: testProps,
             secret: "sekret",
+            globals: {
+                location: "http://www.example.com",
+            },
         };
 
         testJson.urls.forEach((url) => {
@@ -251,6 +254,9 @@ describe("API endpoint /render", function() {
             path: "./javascript/server-package/test-component.jsx",
             props: testProps,
             secret: "sekret",
+            globals: {
+                location: "http://www.example.com",
+            },
         };
 
         testJson.urls.forEach((url) => {
@@ -266,8 +272,7 @@ describe("API endpoint /render", function() {
         });
 
         const expected =
-            "Fetching failure: Error: " +
-            "cannot undefined /webpacked/common/1.js (404): ";
+            "FETCH FAIL (http://www.example.com): Error: cannot undefined /webpacked/common/1.js (404)";
 
         // Act
         await agent.post("/render").send(testJson);
@@ -276,7 +281,7 @@ describe("API endpoint /render", function() {
         let foundLogMessage = false;
         errorLoggingSpy.args.forEach((arglist) => {
             arglist.forEach((arg) => {
-                if (arg === expected) {
+                if (arg.indexOf(expected) === 0) {
                     foundLogMessage = true;
                 }
             });


### PR DESCRIPTION
We are seeing these errors getting logged and yet the error information
we are trying to embed in the log metadata is not there. This makes
working out what really happened a lot harder.

So, here we instead try to get the error information into a the
log string itself so that we can see what's happening in our logs.

# Test plan

We don't have a great story right now for testing our failure modes.
However, we can test this by sending a bad request that requests URLs
that we know don't exist, or by sending a request that uses JS that we
know will blow up when executed.

To do the second part, we need to serve a file that is broken. We can
coerce a webapp to do this.