### PR TITLE
WEB-1757: Retry fetches on 404 errors

### DIFF
--- a/src/fetch_package.js
+++ b/src/fetch_package.js
@@ -196,18 +196,6 @@ export default async function fetchPackage(
         abort = abortFn;
     };
     const fetchPromise = doFetch(Date.now(), registerAbortFn).catch((err) => {
-        if (
-            err.response &&
-            err.response.status >= 400 &&
-            err.response.status < 500
-        ) {
-            // One could imagine adding a 'negative' cache
-            // entry for 4xx errors, maybe with a maxAge of 1
-            // minute, but unless we see this being a problem
-            // in practice it's not worth the code complexity.
-            throw err;
-        }
-
         // If we get here, we have a 5xx error or similar
         // (socket timeout, maybe).  Let's retry a few times.
         if (triesLeftAfterThisOne > 0) {

--- a/src/fetch_package_test.js
+++ b/src/fetch_package_test.js
@@ -36,8 +36,10 @@ describe("fetchPackage", () => {
         mockScope.done();
     });
 
-    it("should fail on 4xx", async () => {
+    it("should retry on 4xx", async () => {
         // Arrange
+        mockScope.get("/ok.js").reply(404, "global._fetched = 'boo';");
+        mockScope.get("/ok.js").reply(404, "global._fetched = 'boo';");
         mockScope.get("/ok.js").reply(404, "global._fetched = 'boo';");
 
         // Act
@@ -46,6 +48,7 @@ describe("fetchPackage", () => {
         } catch (e) {
             // Assert
             assert.equal(404, e.response.status);
+            mockScope.done();
             return;
         }
         throw new Error("Should have failed on 4xx");

--- a/src/server_test.js
+++ b/src/server_test.js
@@ -262,6 +262,9 @@ describe("API endpoint /render", function() {
                     .reply(404);
                 return;
             }
+            // We attempt retry 3 times on a 404 error
+            mockScope.get(path).reply(404);
+            mockScope.get(path).reply(404);
             mockScope.get(path).reply(404);
         });
 


### PR DESCRIPTION
It's possible that some of the 404 errors we're seeing from Fastly may be transient. So let's retry them!

Issue: https://khanacademy.atlassian.net/browse/WEB-1757

Test plan:
I ran the test suite and it passed.