### PR TITLE
WEB-1759: Add tests verifying that superagent-cache-plugin works

### DIFF
--- a/src/fetch_package_test.js
+++ b/src/fetch_package_test.js
@@ -1,8 +1,10 @@
 // @flow
 
-import fetchPackage from "./fetch_package.js";
+import fetchPackage, {flushCache} from "./fetch_package.js";
+import args from "./arguments.js";
 import {assert} from "chai";
 import nock from "nock";
+import sinon from "sinon";
 
 describe("fetchPackage", () => {
     let mockScope;
@@ -84,6 +86,97 @@ describe("fetchPackage", () => {
         } catch (e) {
             // Assert
             assert.equal(500, e.response.status);
+            mockScope.done();
+            return;
+        }
+
+        throw new Error("Should have failed on 5xx");
+    });
+
+    it("should succeed on 5xx followed by 200", async () => {
+        // Arrange
+        mockScope.get("/ok.js").reply(500, "global._fetched = 'boo';");
+        mockScope.get("/ok.js").reply(200, "global._fetched = 'yay!';");
+
+        // Act
+        const result = await fetchPackage("https://www.ka.org/ok.js", "TEST");
+
+        // Assert
+        assert.equal(result.url, "https://www.ka.org/ok.js");
+        assert.equal(result.content, "global._fetched = 'yay!';");
+        mockScope.done();
+    });
+});
+
+describe("fetchPackage with cache", () => {
+    let mockScope;
+
+    before(() => {
+        nock.disableNetConnect();
+        nock.enableNetConnect("127.0.0.1");
+    });
+
+    beforeEach(() => {
+        global._fetched = undefined;
+        mockScope = nock("https://www.ka.org");
+        sinon.stub(args, "useCache").get(() => true);
+    });
+
+    afterEach(() => {
+        flushCache();
+        global._fetched = undefined;
+        nock.cleanAll();
+        sinon.restore();
+    });
+
+    it("should only fetch once for multiple requests", async () => {
+        // Arrange
+        mockScope.get("/ok.js").reply(200, "global._fetched = 'yay!';");
+        mockScope.get("/ok.js").reply(200, "global._fetched = 'ignored';");
+
+        // Act
+        const result0 = await fetchPackage("https://www.ka.org/ok.js", "TEST");
+        const result1 = await fetchPackage("https://www.ka.org/ok.js", "TEST");
+
+        // Assert
+        assert.equal(result0.content, result1.content);
+        // We should still have pending mocks; the second request
+        // should never have gotten sent.
+        assert.notEqual(0, mockScope.pendingMocks().length);
+    });
+
+    it("should retry on 4xx even with cache", async () => {
+        // Arrange
+        mockScope.get("/ok.js").reply(404, "global._fetched = 'boo';");
+        mockScope.get("/ok.js").reply(404, "global._fetched = 'boo';");
+        mockScope.get("/ok.js").reply(404, "global._fetched = 'boo';");
+
+        // Act
+        try {
+            await fetchPackage("https://www.ka.org/ok.js", "TEST");
+        } catch (e) {
+            // Assert
+            assert.equal(404, e.response.status);
+            assert.equal(0, mockScope.pendingMocks().length);
+            mockScope.done();
+            return;
+        }
+        throw new Error("Should have failed on 4xx");
+    });
+
+    it("should retry on 5xx", async () => {
+        // Arrange
+        mockScope.get("/ok.js").reply(500, "global._fetched = 'boo';");
+        mockScope.get("/ok.js").reply(500, "global._fetched = 'boo';");
+        mockScope.get("/ok.js").reply(500, "global._fetched = 'boo';");
+
+        // Act
+        try {
+            await fetchPackage("https://www.ka.org/ok.js", "TEST");
+        } catch (e) {
+            // Assert
+            assert.equal(500, e.response.status);
+            assert.equal(0, mockScope.pendingMocks().length);
             mockScope.done();
             return;
         }

--- a/src/fetch_package_test.js
+++ b/src/fetch_package_test.js
@@ -93,6 +93,20 @@ describe("fetchPackage", () => {
         throw new Error("Should have failed on 5xx");
     });
 
+    it("should succeed on 4xx followed by 200", async () => {
+        // Arrange
+        mockScope.get("/ok.js").reply(404, "global._fetched = 'boo';");
+        mockScope.get("/ok.js").reply(200, "global._fetched = 'yay!';");
+
+        // Act
+        const result = await fetchPackage("https://www.ka.org/ok.js", "TEST");
+
+        // Assert
+        assert.equal(result.url, "https://www.ka.org/ok.js");
+        assert.equal(result.content, "global._fetched = 'yay!';");
+        mockScope.done();
+    });
+
     it("should succeed on 5xx followed by 200", async () => {
         // Arrange
         mockScope.get("/ok.js").reply(500, "global._fetched = 'boo';");
@@ -182,6 +196,20 @@ describe("fetchPackage with cache", () => {
         }
 
         throw new Error("Should have failed on 5xx");
+    });
+
+    it("should succeed on 4xx followed by 200", async () => {
+        // Arrange
+        mockScope.get("/ok.js").reply(404, "global._fetched = 'boo';");
+        mockScope.get("/ok.js").reply(200, "global._fetched = 'yay!';");
+
+        // Act
+        const result = await fetchPackage("https://www.ka.org/ok.js", "TEST");
+
+        // Assert
+        assert.equal(result.url, "https://www.ka.org/ok.js");
+        assert.equal(result.content, "global._fetched = 'yay!';");
+        mockScope.done();
     });
 
     it("should succeed on 5xx followed by 200", async () => {


### PR DESCRIPTION
We were worried that it might be caching error responses, but that doesn't seem to be the case based on my testing. I ended up adding a bunch of tests anyway, might as well keep them!

Issue: https://khanacademy.atlassian.net/browse/WEB-1759

Test plan:
`npm test`