### PR TITLE
[WEB-1753] Add abort to Promise prototype

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -18,3 +18,5 @@
 emoji=true
 exact_by_default=true
 module.use_strict=true
+suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe
+suppress_comment=\\(.\\|\n\\)*\\$FlowIgnore

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,8 @@
     "javascript.validate.enable": false,
     "coverage-gutters.lcovname": "./coverage/lcov.info",
     "jest.enableSnapshotUpdateMessages": false,
-    "jest.pathToConfig": "./config/jest/test.config.js"
+    "jest.pathToConfig": "./config/jest/test.config.js",
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": true
+    }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "clean": "rm -rf dist",
     "start": "node dist/main.js -p 8080 --log-level=debug",
     "serve_local": "npm run build && nodemon dist/main.js -- --dev --log-level=silly --port=8040",
-    "test": "NODE_ENV=test mocha --exit --reporter spec 'src/*_test.js' --require @babel/register --require test_setup.js",
+    "test": "NODE_ENV=test mocha --exit --reporter spec --require @babel/register --require test_setup.js 'src/*_test.js'",
     "deploy": "./deploy.sh",
     "deploy:docker": "DOCKER=1 ./deploy.sh",
     "set_default": "./set_default.sh",

--- a/src/create-render-context.js
+++ b/src/create-render-context.js
@@ -4,15 +4,16 @@
  * Create a render context object.
  */
 
+// eslint-disable-next-line import/no-unassigned-import
+import "./patch-promise.js";
+
 import vm from "vm";
 
-import {JSDOM, ResourceLoader, VirtualConsole} from "jsdom";
+import {JSDOM, VirtualConsole} from "jsdom";
 
-import logging from "./logging.js";
 import profile from "./profile.js";
-import fetchPackage from "./fetch_package.js";
+import {CustomResourceLoader} from "./custom-resource-loader.js";
 
-import type {FetchOptions} from "jsdom";
 import type {
     Globals,
     JavaScriptPackage,
@@ -24,94 +25,6 @@ type RenderContextWithSize = {
     context: RenderContext,
     cumulativePackageSize: number,
 };
-
-class CustomResourceLoader extends ResourceLoader {
-    _active: boolean;
-    _requestStats: ?RequestStats;
-
-    /**
-     * We will return EMPTY in cases where we just don't care about the file
-     * loading. Let's just reuse a promise for that.
-     */
-    static EMPTY = Promise.resolve(Buffer.from(""));
-
-    constructor(requestStats?: RequestStats) {
-        super();
-
-        (CustomResourceLoader.EMPTY: any).abort =
-            (CustomResourceLoader.EMPTY: any).abort || (() => {});
-        this._active = true;
-        this._requestStats = requestStats;
-    }
-
-    close(): void {
-        this._active = false;
-    }
-
-    _fetchJavaScript(url: string): Promise<Buffer> {
-        const abortableFetch = fetchPackage(url, "JSDOM", this._requestStats);
-        const promiseToBuffer = abortableFetch.then(({content}) => {
-            if (!this._active) {
-                logging.silly(`File requested but never used (${url})`);
-
-                /**
-                 * We can return an empty buffer here without caching the
-                 * empty result because the actual file is already cached
-                 * by our package fetching. So this does not impact future
-                 * renders.
-                 */
-                return Buffer.from("");
-            }
-            return Buffer.from(content);
-        });
-        /**
-         * We have to turn this back into an abortable promise so that JSDOM
-         * can abort it when closing, if it needs to.
-         */
-        (promiseToBuffer: any).abort = abortableFetch.abort;
-        return promiseToBuffer;
-    }
-
-    fetch(url: string, options: FetchOptions): ?Promise<Buffer> {
-        const isInlineData = url.startsWith("data:");
-        const loggableUrl = isInlineData ? "inline data" : url;
-        if (!this._active) {
-            // Let's head off any fetches that occur after we're inactive.
-            // Not sure if we get any, but now we'll know.
-            logging.warn(
-                `File fetch tried by JSDOM after render (${loggableUrl})`,
-            );
-
-            /**
-             * Though we intentionally don't want to load this file, we can't
-             * just return null per the spec as this can break promise
-             * resolutions that are relying on this file. Instead, we resolve
-             * as an empty string so things can tidy up properly.
-             */
-            return CustomResourceLoader.EMPTY;
-        }
-
-        // If this is not a JavaScript request or the JSDOM context has been
-        // closed by our rendering, then return an empty result as we don't
-        // need them for SSR-ing
-        const JSFileRegex = /^.*\.js(?:\?.*)?/g;
-        if (!JSFileRegex.test(url) || !this._active) {
-            logging.silly("EMPTY: %s", loggableUrl);
-
-            /**
-             * Though we intentionally don't want to load this file, we can't
-             * just return null per the spec as this can break promise
-             * resolutions that are relying on this file. Instead, we resolve
-             * as an empty string.
-             */
-            return CustomResourceLoader.EMPTY;
-        }
-
-        // If this is a JavaScript request, then we want to do some things to
-        // request it ourselves, before we let JSDOM handle the result.
-        return this._fetchJavaScript(url);
-    }
-}
 
 const getScript = function(
     fnOrText: Function | string,

--- a/src/create-render-context.js
+++ b/src/create-render-context.js
@@ -4,9 +4,6 @@
  * Create a render context object.
  */
 
-// eslint-disable-next-line import/no-unassigned-import
-import "./patch-promise.js";
-
 import vm from "vm";
 
 import {JSDOM, VirtualConsole} from "jsdom";

--- a/src/custom-resource-loader.js
+++ b/src/custom-resource-loader.js
@@ -1,0 +1,103 @@
+// @flow
+
+// eslint-disable-next-line import/no-unassigned-import
+import "./patch-promise.js";
+
+import {ResourceLoader} from "jsdom";
+
+import logging from "./logging.js";
+import fetchPackage from "./fetch_package.js";
+
+import type {FetchOptions} from "jsdom";
+import type {RequestStats} from "./types.js";
+
+export class CustomResourceLoader extends ResourceLoader {
+    _active: boolean;
+    _requestStats: ?RequestStats;
+
+    /**
+     * We will return EMPTY in cases where we just don't care about the file
+     * loading. Let's just reuse a promise for that.
+     */
+    static EMPTY = Promise.resolve(Buffer.from(""));
+
+    constructor(requestStats?: RequestStats) {
+        super();
+
+        this._active = true;
+        this._requestStats = requestStats;
+    }
+
+    get isActive(): boolean {
+        return this._active;
+    }
+
+    close(): void {
+        this._active = false;
+    }
+
+    _fetchJavaScript(url: string): Promise<Buffer> {
+        const abortableFetch = fetchPackage(url, "JSDOM", this._requestStats);
+        const promiseToBuffer = abortableFetch.then(({content}) => {
+            if (!this._active) {
+                logging.silly(`File requested but never used (${url})`);
+
+                /**
+                 * We can return an empty buffer here without caching the
+                 * empty result because the actual file is already cached
+                 * by our package fetching. So this does not impact future
+                 * renders.
+                 */
+                return Buffer.from("");
+            }
+            return Buffer.from(content);
+        });
+
+        /**
+         * We have to turn this back into an abortable promise so that JSDOM
+         * can abort it when closing, if it needs to.
+         */
+        (promiseToBuffer: any).abort = abortableFetch.abort;
+        return promiseToBuffer;
+    }
+
+    fetch(url: string, options: FetchOptions): ?Promise<Buffer> {
+        const isInlineData = url.startsWith("data:");
+        const loggableUrl = isInlineData ? "inline data" : url;
+        if (!this._active) {
+            // Let's head off any fetches that occur after we're inactive.
+            // Not sure if we get any, but now we'll know.
+            logging.warn(
+                `File fetch tried by JSDOM after render (${loggableUrl})`,
+            );
+
+            /**
+             * Though we intentionally don't want to load this file, we can't
+             * just return null per the spec as this can break promise
+             * resolutions that are relying on this file. Instead, we resolve
+             * as an empty string so things can tidy up properly.
+             */
+            return CustomResourceLoader.EMPTY;
+        }
+
+        // If this is not a JavaScript request or the JSDOM context has been
+        // closed by our rendering, then return an empty result as we don't
+        // need them for SSR-ing
+        const JSFileRegex = /^.*\.js(?:\?.*)?/g;
+        if (!JSFileRegex.test(url) || !this._active) {
+            logging.silly("EMPTY: %s", loggableUrl);
+
+            /**
+             * Though we intentionally don't want to load this file, we can't
+             * just return null per the spec as this can break promise
+             * resolutions that are relying on this file. Instead, we resolve
+             * as an empty string.
+             */
+            return CustomResourceLoader.EMPTY;
+        }
+
+        // If this is a JavaScript request, then we want to do some things to
+        // request it ourselves, before we let JSDOM handle the result.
+        return this._fetchJavaScript(url);
+    }
+}

--- a/src/custom-resource-loader.js
+++ b/src/custom-resource-loader.js
@@ -1,7 +1,6 @@
 // @flow
 
-// eslint-disable-next-line import/no-unassigned-import
-import "./patch-promise.js";
+import {applyAbortPatch} from "./patch-promise.js";
 
 import {ResourceLoader} from "jsdom";
 
@@ -10,6 +9,11 @@ import fetchPackage from "./fetch_package.js";
 
 import type {FetchOptions} from "jsdom";
 import type {RequestStats} from "./types.js";
+
+/**
+ * Make sure any promises that get made have an abort.
+ */
+applyAbortPatch();
 
 export class CustomResourceLoader extends ResourceLoader {
     _active: boolean;

--- a/src/custom-resource-loader_test.js
+++ b/src/custom-resource-loader_test.js
@@ -1,0 +1,264 @@
+// @flow
+import * as sinon from "sinon";
+import {assert} from "chai";
+import {ResourceLoader} from "jsdom";
+import logging from "./logging.js";
+import * as FetchPackageModule from "./fetch_package.js";
+import {CustomResourceLoader} from "./custom-resource-loader.js";
+
+import type {RequestStats} from "./types.js";
+
+describe("CustomResourceLoader", () => {
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    describe("EMPTY", () => {
+        it("should be a resolved promise of an empty Buffer", async () => {
+            // Arrange
+            const underTest = CustomResourceLoader.EMPTY;
+
+            // Act
+            const result = await underTest;
+
+            // Assert
+            assert.instanceOf(result, Buffer);
+            assert.equal(result.toString(), "");
+        });
+
+        it("should have an abort function", () => {
+            // Arrange
+            // Cast to any so we can use abort method without flow complaints
+            const underTest: any = CustomResourceLoader.EMPTY;
+
+            // Act
+            const result = underTest.abort;
+
+            // Assert
+            assert.typeOf(result, "function");
+        });
+    });
+
+    describe("#constructor", () => {
+        it("should set isActive to true", () => {
+            // Arrange
+
+            // Act
+            const underTest = new CustomResourceLoader();
+            const result = underTest.isActive;
+
+            // Assert
+            assert.isTrue(result);
+        });
+
+        it("should derive from JSDOM ResourceLoader", () => {
+            // Arrange
+
+            // Act
+            const underTest = new CustomResourceLoader();
+
+            // Assert
+            assert.instanceOf(underTest, ResourceLoader);
+        });
+    });
+
+    describe("#close", () => {
+        it("should set isActive to false", () => {
+            // Arrange
+            const underTest = new CustomResourceLoader();
+
+            // Act
+            underTest.close();
+            const result = underTest.isActive;
+
+            // Assert
+            assert.isFalse(result);
+        });
+    });
+
+    describe("#fetch", () => {
+        describe("when not a JavaScript file", () => {
+            it("should return EMPTY promise", () => {
+                // Arrange
+                const underTest = new CustomResourceLoader();
+
+                // Act
+                const result = underTest.fetch(
+                    "http://example.com/test.png",
+                    {},
+                );
+
+                // Assert
+                assert.equal(result, CustomResourceLoader.EMPTY);
+            });
+        });
+
+        describe("when a JavaScript file", () => {
+            it("should invoke fetchPackage", () => {
+                // Arrange
+                const fetchPackageSpy = sinon
+                    .stub(FetchPackageModule, "default")
+                    .returns(new Promise((resolve, reject) => {}));
+                const underTest = new CustomResourceLoader();
+
+                // Act
+                underTest.fetch("http://example.com/test.js", {});
+
+                // Assert
+                sinon.assert.calledWith(
+                    fetchPackageSpy,
+                    "http://example.com/test.js",
+                    "JSDOM",
+                );
+            });
+
+            it("should invoke fetchPackage with requestStats", () => {
+                // Arrange
+                const fetchPackageSpy = sinon
+                    .stub(FetchPackageModule, "default")
+                    .returns(new Promise((resolve, reject) => {}));
+                const requestStats: RequestStats = {
+                    pendingRenderRequests: 0,
+                    packageFetches: 0,
+                    fromCache: 0,
+                    vmContextSize: 0,
+                    createdVmContext: true,
+                };
+                const underTest = new CustomResourceLoader(requestStats);
+
+                // Act
+                underTest.fetch("http://example.com/test.js", {});
+
+                // Assert
+                sinon.assert.calledWith(
+                    fetchPackageSpy,
+                    "http://example.com/test.js",
+                    "JSDOM",
+                    requestStats,
+                );
+            });
+
+            it("should resolve with buffer of content", async () => {
+                // Arrange
+                const content = "THIS IS CONTENT!";
+                sinon
+                    .stub(FetchPackageModule, "default")
+                    .returns(Promise.resolve({content}));
+                const underTest = new CustomResourceLoader();
+
+                // Act
+                // It will not be null $FlowIgnore
+                const result = await underTest.fetch(
+                    "http://example.com/test.js",
+                    {},
+                );
+
+                // Assert
+                assert.instanceOf(result, Buffer);
+                assert.equal(result.toString(), content);
+            });
+
+            it("should have abort that will invoke abort on underlying fetch", () => {
+                // Arrange
+                const fetchPromise = Promise.resolve({content: "CONTENT"});
+                const abortSpy = sinon.spy(fetchPromise, "abort");
+                sinon.stub(FetchPackageModule, "default").returns(fetchPromise);
+                const underTest = new CustomResourceLoader();
+
+                // Act
+                const result = underTest.fetch(
+                    "http://example.com/test.js",
+                    {},
+                );
+                // We know that this really exists because we patch it
+                // to be there $FlowIgnore
+                result.abort();
+
+                // Assert
+                sinon.assert.calledOnce(abortSpy);
+            });
+
+            it("should resolve to empty buffer if resolved after close()", async () => {
+                // Arrange
+                const clock = sinon.useFakeTimers();
+                sinon.stub(FetchPackageModule, "default").returns(
+                    new Promise((resolve, reject) => {
+                        setTimeout(() => resolve({content: ""}), 0);
+                    }),
+                );
+                const underTest = new CustomResourceLoader();
+
+                // Act
+                const fetchPromise = underTest.fetch(
+                    "http://example.com/test.js",
+                    {},
+                );
+                underTest.close();
+                clock.tick(1);
+                // It will not be null $FlowIgnore
+                const result = await fetchPromise;
+
+                // Assert
+                assert.instanceOf(result, Buffer);
+                assert.equal(result.toString(), "");
+            });
+
+            it("should log silly if resolved after close()", async () => {
+                // Arrange
+                const clock = sinon.useFakeTimers();
+                const sillySpy = sinon.spy(logging, "silly");
+                sinon.stub(FetchPackageModule, "default").returns(
+                    new Promise((resolve, reject) => {
+                        setTimeout(() => resolve({content: ""}), 0);
+                    }),
+                );
+                const underTest = new CustomResourceLoader();
+
+                // Act
+                const fetchPromise = underTest.fetch(
+                    "http://example.com/test.js",
+                    {},
+                );
+                underTest.close();
+                clock.tick(1);
+                await fetchPromise;
+
+                // Assert
+                sinon.assert.calledWith(
+                    sillySpy,
+                    "File requested but never used (http://example.com/test.js)",
+                );
+            });
+        });
+
+        describe("when called after close(); isActive = false", () => {
+            it("should log warning", () => {
+                // Arrange
+                const warnSpy = sinon.spy(logging, "warn");
+                const underTest = new CustomResourceLoader();
+                underTest.close();
+
+                // Act
+                underTest.fetch("http://example.com", {});
+
+                // Assert
+                sinon.assert.calledWith(
+                    warnSpy,
+                    "File fetch tried by JSDOM after render (http://example.com)",
+                );
+            });
+
+            it("should return EMPTY", () => {
+                // Arrange
+                const underTest = new CustomResourceLoader();
+                underTest.close();
+
+                // Act
+                const result = underTest.fetch("http://example.com", {});
+
+                // Assert
+                assert.equal(result, CustomResourceLoader.EMPTY);
+            });
+        });
+    });
+});

--- a/src/main.js
+++ b/src/main.js
@@ -3,9 +3,6 @@
  * The main entrypoint for our react-component render server.
  */
 
-// eslint-disable-next-line import/no-unassigned-import
-import "./patch-promise.js";
-
 import express from "express";
 
 import args from "./arguments.js";

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,9 @@
  * The main entrypoint for our react-component render server.
  */
 
+// eslint-disable-next-line import/no-unassigned-import
+import "./patch-promise.js";
+
 import express from "express";
 
 import args from "./arguments.js";

--- a/src/patch-promise.js
+++ b/src/patch-promise.js
@@ -8,28 +8,27 @@
  * working, so let's go right down to the base of the problem and patch
  * the promise prototype.
  */
-const applyAbortPatch = () => {
+export const applyAbortPatch = () => {
     /**
      * We know that this doesn't exist on the promise type.
-     * But we're getting rid of it if it does. Other things can replace
-     * it if they so choose.
+     * But we're getting rid of it if it does and it is not ours.
+     * Other things can replace it if they so choose.
      * $FlowIgnore
      */
-    if (Promise.prototype.abort) {
+    if (Promise.prototype.abort && !Promise.prototype.abort.__rrs_patched__) {
+        // $FlowIgnore
         delete Promise.prototype.abort;
     }
+
+    /**
+     * Make a noop and tag it as our patched version.
+     */
+    const ourAbort = () => {};
+    ourAbort.__rrs_patched__ = true;
 
     /**
      * We still know that this doesn't exist on the promise type.
      * $FlowIgnore
      */
-    Promise.prototype.abort = () => {};
+    Promise.prototype.abort = ourAbort;
 };
-
-/**
- * Don't usually like side-effects in imports, but this enables us to import
- * this in the files we want and know it just works which is useful for
- * ensuring the tests will work without explicit knowledge of the need for this
- * patch.
- */
-applyAbortPatch();

--- a/src/patch-promise.js
+++ b/src/patch-promise.js
@@ -1,0 +1,35 @@
+// @flow
+/**
+ * We use JSDOM for lots of things right now. When we close the JSDOM context
+ * it tries to abort any outstanding fetches. It assumes these all have an
+ * `abort` function, but that isn't the case if they are regular promises.
+ *
+ * We tried to mitigate this within our custom resource loader but it is not
+ * working, so let's go right down to the base of the problem and patch
+ * the promise prototype.
+ */
+const applyAbortPatch = () => {
+    /**
+     * We know that this doesn't exist on the promise type.
+     * But we're getting rid of it if it does. Other things can replace
+     * it if they so choose.
+     * $FlowIgnore
+     */
+    if (Promise.prototype.abort) {
+        delete Promise.prototype.abort;
+    }
+
+    /**
+     * We still know that this doesn't exist on the promise type.
+     * $FlowIgnore
+     */
+    Promise.prototype.abort = () => {};
+};
+
+/**
+ * Don't usually like side-effects in imports, but this enables us to import
+ * this in the files we want and know it just works which is useful for
+ * ensuring the tests will work without explicit knowledge of the need for this
+ * patch.
+ */
+applyAbortPatch();


### PR DESCRIPTION
This makes it so that all our promises are patched to have an abort
call by modifying the Promise prototype. The aim is to make sure that
when JSDOM closes, there is an abort function for it to call, working
around its bug where it assumes all fetched promises are abortable this way.

This also takes the `CustomResourceLoader` code and gives it its own
file and tests. This helps validate a core piece of our architecture
as well as verify that our patching is working.