### PR TITLE
1. Add URL to errors for Apollo

### DIFF
--- a/src/configure-apollo-network.js
+++ b/src/configure-apollo-network.js
@@ -51,7 +51,9 @@ export default function configureApolloNetwork(
 
     const handleNetworkFetch = async (url: string, params: any) => {
         if (!url || url === BAD_URL) {
-            throw new Error("ApolloNetwork must have a valid url.");
+            throw new Error(
+                `ApolloNetwork must have a valid url (URL: ${url})`,
+            );
         }
 
         const result = await Promise.race([
@@ -60,13 +62,13 @@ export default function configureApolloNetwork(
             // it's still on-going.
             timeout(
                 apolloNetwork.timeout || 1000,
-                "Server response exceeded timeout.",
+                `Server response exceeded timeout (URL: ${url})`,
             ),
         ]);
 
         // Handle server errors
         if (!result || result.status !== 200) {
-            throw new Error("Server returned an error.");
+            throw new Error(`Server returned an error (URL: ${url})`);
         }
 
         return result;

--- a/src/render_apollo_test.js
+++ b/src/render_apollo_test.js
@@ -257,7 +257,7 @@ describe("render apollo", () => {
         // Assert
         await assert.isRejected(
             underTest,
-            "Network error: ApolloNetwork must have a valid url.",
+            "Network error: ApolloNetwork must have a valid url (URL: BAD_URL)",
         );
     });
 
@@ -286,7 +286,7 @@ describe("render apollo", () => {
         // Assert
         await assert.isRejected(
             underTest,
-            "Network error: Server returned an error.",
+            "Network error: Server returned an error (URL: https://www.ka.org/graphql)",
         );
     });
 
@@ -315,7 +315,7 @@ describe("render apollo", () => {
         // Assert
         await assert.isRejected(
             underTest,
-            "Network error: Server returned an error.",
+            "Network error: Server returned an error (URL: https://www.ka.org/graphql)",
         );
     });
 
@@ -376,7 +376,7 @@ describe("render apollo", () => {
         // Assert
         await assert.isRejected(
             underTest,
-            "Network error: Server response exceeded timeout.",
+            "Network error: Server response exceeded timeout (URL: https://www.ka.org/graphql)",
         );
     });
 
@@ -409,7 +409,7 @@ describe("render apollo", () => {
         // Assert
         await assert.isRejected(
             underTest,
-            "Network error: Server response exceeded timeout.",
+            "Network error: Server response exceeded timeout (URL: https://www.ka.org/graphql)",
         );
     });
 });


### PR DESCRIPTION
This is a diagnostics change. I've added the URL of the request being made so that we can verify it's what we expect.