### PR TITLE
Get logging using the google middleware

### DIFF
--- a/flow-typed/custom/@google-cloud/logging-winston.js
+++ b/flow-typed/custom/@google-cloud/logging-winston.js
@@ -1,20 +1,24 @@
-import {Transport} from "winston";
-
 declare type loggingwinston$Callback = (err: Error, apiResponse: {...}) => void;
 
 declare interface loggingwinston$Options {
     // TODO: Fill this out
 }
 
-declare class loggingwinston$LoggingWinston extends Transport {
+declare class loggingwinston$LoggingWinston extends $winstonTransport {
   constructor(options?: loggingwinston$Options): this;
   log(info: any, callback: loggingwinston$Callback): void;
+}
+
+declare interface loggingwinston$express {
+    makeMiddleware(logger: $winstonLogger, transport: loggingwinston$LoggingWinston): Promise<express$Middleware>;
+    makeMiddleware(logger: $winstonLogger, options?: loggingwinston$Options): Promise<express$Middleware>;
 }
 
 
 declare module '@google-cloud/logging-winston' {
     declare module.exports: {
-        LoggingWinston: typeof loggingwinston$LoggingWinston
+        LoggingWinston: typeof loggingwinston$LoggingWinston,
+        express: loggingwinston$express
     }
 }
 

--- a/flow-typed/npm/winston_v3.x.x.js
+++ b/flow-typed/npm/winston_v3.x.x.js
@@ -30,18 +30,18 @@ declare type $winstonFileTransportConfig<T: $winstonLevels> = {
   ...
 };
 
-declare class $winstonTransport {
+declare interface $winstonTransport {
   level?: string;
   silent?: boolean;
 }
 
-declare class $winstonFileTransport<T> extends $winstonTransport {
+declare class $winstonFileTransport<T> implements $winstonTransport {
   constructor($winstonFileTransportConfig<T>): $winstonFileTransport<T>;
 }
 
 declare type $winstonConsoleTransportConfig<T: $winstonLevels> = { level?: $Keys<T>, ... };
 
-declare class $winstonConsoleTransport<T> extends $winstonTransport {
+declare class $winstonConsoleTransport<T> implements $winstonTransport {
   constructor(
     config?: $winstonConsoleTransportConfig<T>
   ): $winstonConsoleTransport<T>;
@@ -55,7 +55,7 @@ declare type $winstonStreamTransportConfig<T: $winstonLevels> = {
   ...,
 };
 
-declare class $winstonStreamTransport<T> extends $winstonTransport {
+declare class $winstonStreamTransport<T> implements $winstonTransport {
   constructor(config?: $winstonStreamTransportConfig<T>): $winstonStreamTransport<T>;
 }
 // End: https://github.com/Khan/react-render-server/pull/20
@@ -153,7 +153,7 @@ declare module "winston" {
   declare export type Info<T: Levels > = $winstonInfo<T>;
   declare export type Format = $winstonFormat;
   declare export type FileTransportConfig<T: Levels> = $winstonFileTransportConfig<T>;
-  declare export type Transport = typeof $winstonTransport;
+  declare export type Transport = $winstonTransport;
   declare export type FileTransport<T: Levels> = $winstonFileTransport<T>;
   declare export type ConsoleTransportConfig<T: Levels> = $winstonConsoleTransportConfig<T>;
   declare export type ConsoleTransport<T: Levels> = $winstonConsoleTransport<T>;

--- a/src/logging.js
+++ b/src/logging.js
@@ -110,24 +110,22 @@ export function extractErrorInfo(error: any): string {
     return `${error}`;
 }
 
-export function makeErrorMiddleware(logger: Logger): Promise<Middleware> {
+export function makeErrorMiddleware(logger: Logger): Middleware {
     // This is the logger that captures errors in our express server.
-    return Promise.resolve(
-        expressWinston.errorLogger({
-            /**
-             * Specify the level that this logger logs at.
-             * (use a function to dynamically change level based on req, res and
-             * err)
-             *     `function(req, res, err) { return String; }`
-             */
-            level: "error",
+    return expressWinston.errorLogger({
+        /**
+         * Specify the level that this logger logs at.
+         * (use a function to dynamically change level based on req, res and
+         * err)
+         *     `function(req, res, err) { return String; }`
+         */
+        level: "error",
 
-            /**
-             * Use the logger we already set up.
-             */
-            winstonInstance: logger,
-        }),
-    );
+        /**
+         * Use the logger we already set up.
+         */
+        winstonInstance: logger,
+    });
 }
 
 export async function makeRequestMiddleware(

--- a/src/main.js
+++ b/src/main.js
@@ -6,83 +6,94 @@
 import express from "express";
 
 import args from "./arguments.js";
-import logging, {middleware} from "./logging.js";
+import logging, {
+    extractErrorInfo,
+    makeErrorMiddleware,
+    makeRequestMiddleware,
+} from "./logging.js";
 import app from "./server.js";
 
-/**
- * Let's begin by logging our arguments.
- */
-logging.debug(`Parsed arguments: ${args.toString()}`);
+async function main() {
+    /**
+     * Let's begin by logging our arguments.
+     */
+    logging.debug(`Parsed arguments: ${args.toString()}`);
 
-/**
- * In production mode, we want to hook up to various StackDriver services.
- */
-if (!args.dev) {
-    // Start logging agent for Cloud Trace (https://cloud.google.com/trace/).
-    const traceAgent = require("@google-cloud/trace-agent");
-    traceAgent.start({logLevel: 2}); // log at WARN and ERROR
+    /**
+     * In production mode, we want to hook up to various StackDriver services.
+     */
+    if (!args.dev) {
+        // Start logging agent for Cloud Trace (https://cloud.google.com/trace/).
+        const traceAgent = require("@google-cloud/trace-agent");
+        traceAgent.start({logLevel: 2}); // log at WARN and ERROR
 
-    const debugAgent = require("@google-cloud/debug-agent");
-    debugAgent.start({logLevel: 2});
+        const debugAgent = require("@google-cloud/debug-agent");
+        debugAgent.start({logLevel: 2});
 
-    const profiler = require("@google-cloud/profiler");
-    profiler.start();
+        const profiler = require("@google-cloud/profiler");
+        profiler.start();
+    }
+
+    /**
+     * Make sure we have a NODE_ENV variablewithout overriding the test state.
+     */
+    if (process.env.NODE_ENV !== "test") {
+        if (args.dev) {
+            process.env.NODE_ENV = "dev";
+        } else {
+            // This is important for the default catch-all error handler:
+            // http://expressjs.com/en/guide/error-handling.html
+            process.env.NODE_ENV = "production";
+        }
+    }
+
+    /**
+     * Create the express app.
+     *
+     * Logging support is based on:
+     *   https://cloud.google.com/nodejs/getting-started/logging-application-events
+     *
+     * The order matters here.
+     *
+     * The request logger should come before the app, and the error logger, after.
+     */
+    const appWithLogging = express()
+        .use(await makeRequestMiddleware(logging))
+        .use(app)
+        .use(await makeErrorMiddleware(logging));
+
+    /**
+     * Start the server listening.
+     *
+     * We need the variable so we can reference it inside the error handling
+     * callback. Feels a bit nasty, but it works.
+     */
+    const server = appWithLogging.listen(args.port, (err: ?Error) => {
+        if (server == null || err != null) {
+            logging.error(
+                `react-render-server appears not to have started: ${(err &&
+                    err.message) ||
+                    "Unknown error"}`,
+            );
+            return;
+        }
+
+        const address = server.address();
+        if (address == null || typeof address === "string") {
+            logging.warn(
+                "react-render-server may not have started properly: %s",
+                address,
+            );
+            return;
+        }
+
+        const host = address.address;
+        const port = address.port;
+        logging.info(`react-render-server running at http://${host}:${port}`);
+    });
 }
 
-/**
- * Make sure we have a NODE_ENV variablewithout overriding the test state.
- */
-if (process.env.NODE_ENV !== "test") {
-    if (args.dev) {
-        process.env.NODE_ENV = "dev";
-    } else {
-        // This is important for the default catch-all error handler:
-        // http://expressjs.com/en/guide/error-handling.html
-        process.env.NODE_ENV = "production";
-    }
-}
-
-/**
- * Create the express app.
- *
- * Logging support is based on:
- *   https://cloud.google.com/nodejs/getting-started/logging-application-events
- *
- * The order matters here.
- *
- * The request logger should come before the app, and the error logger, after.
- */
-const appWithLogging = express()
-    .use(middleware.requestLogger)
-    .use(app)
-    .use(middleware.errorLogger);
-
-/**
- * Start the server listening.
- *
- * We need the variable so we can reference it inside the error handling
- * callback. Feels a bit nasty, but it works.
- */
-const server = appWithLogging.listen(args.port, (err: ?Error) => {
-    if (server == null || err != null) {
-        logging.error(
-            `react-render-server appears not to have started: ${(err &&
-                err.message) ||
-                "Unknown error"}`,
-        );
-        return;
-    }
-
-    const address = server.address();
-    if (address == null || typeof address === "string") {
-        logging.warn(
-            "react-render-server may not have started properly: %s",
-            address,
-        );
-        return;
-    }
-
-    const host = address.address;
-    const port = address.port;
-    logging.info(`react-render-server running at http://${host}:${port}`);
+main().catch((err) => {
+    const errorString = extractErrorInfo(err);
+    logging.error(`Error caught from main setup: ${errorString}`);
 });

--- a/src/main.js
+++ b/src/main.js
@@ -60,7 +60,7 @@ async function main() {
     const appWithLogging = express()
         .use(await makeRequestMiddleware(logging))
         .use(app)
-        .use(await makeErrorMiddleware(logging));
+        .use(makeErrorMiddleware(logging));
 
     /**
      * Start the server listening.

--- a/src/server.js
+++ b/src/server.js
@@ -6,7 +6,7 @@
 import bodyParser from "body-parser";
 import express from "express";
 
-import logging from "./logging.js";
+import logging, {extractErrorInfo} from "./logging.js";
 import profile from "./profile.js";
 
 import fetchPackage, {flushCache} from "./fetch_package.js";
@@ -124,26 +124,6 @@ const checkSecret = function(
         }
         next();
     });
-};
-
-const extractErrorInfo = function(error: any): string {
-    if (typeof error === "string") {
-        return error;
-    }
-
-    if (error.response && error.response.error) {
-        return `${error.response.error}: ${error.stack}`;
-    }
-
-    if (error.error && error !== error.error) {
-        return extractErrorInfo(error.error);
-    }
-
-    if (error.stack) {
-        return error.stack;
-    }
-
-    return `${error}`;
 };
 
 const logAndGetError = function(
@@ -281,6 +261,7 @@ app.post("/render", checkSecret, async (req: $Request, res: $Response) => {
  *
  * We respond with the instance that was flushed.
  * TODO(WEB-1410): how do we flush *all* the instances??
+ *                 Datastore! See graphql-gateway
  */
 app.post("/flush", checkSecret, (req: $Request, res: $Response) => {
     flushCache();


### PR DESCRIPTION
This adds the contextual request logging middleware to the render server.

It does not change things to use the `req.log` call that it adds. That will have to come in a follow-up diff.

Issue: WEB-1769

# Test Plan

We can test this locally with the dev server to verify we're still getting logging output and then we can deploy and try it against the `ab` tool with some real requests before putting in against prod. There should not be any issues.