### PR TITLE
Add ability to scope logging to middleware request logger

### DIFF
--- a/src/create-render-context.js
+++ b/src/create-render-context.js
@@ -16,6 +16,7 @@ import type {
     JavaScriptPackage,
     RenderContext,
     RequestStats,
+    Logger,
 } from "./types.js";
 
 type RenderContextWithSize = {
@@ -110,12 +111,13 @@ const createVirtualConsole = () => {
  * @returns {{context: JSDOM, cumulativePackageSize: number}}
  */
 const createRenderContext = function(
+    logging: Logger,
     locationUrl: string,
     globals: Globals,
     jsPackages: Array<JavaScriptPackage>,
     requestStats?: RequestStats,
 ): RenderContextWithSize {
-    const resourceLoader = new CustomResourceLoader(requestStats);
+    const resourceLoader = new CustomResourceLoader(logging, requestStats);
 
     // A minimal document, for parts of our code that assume there's a DOM.
     const context: RenderContext = (new JSDOM(
@@ -240,16 +242,19 @@ const createRenderContext = function(
  * @returns {JSDOM}
  */
 export default function createRenderContextWithStats(
+    logging: Logger,
     locationUrl: string,
     globals: Globals,
     jsPackages: Array<any>,
     requestStats?: RequestStats,
 ): RenderContext {
     const vmConstructionProfile = profile.start(
+        logging,
         `building VM ${(globals && `for ${globals["location"]}`) || ""}`,
     );
 
     const {context, cumulativePackageSize} = createRenderContext(
+        logging,
         locationUrl,
         globals,
         jsPackages,

--- a/src/custom-resource-loader.js
+++ b/src/custom-resource-loader.js
@@ -4,7 +4,7 @@ import {applyAbortPatch} from "./patch-promise.js";
 
 import {ResourceLoader} from "jsdom";
 
-import logging from "./logging.js";
+import {getScopedLogger} from "./logging.js";
 import fetchPackage from "./fetch_package.js";
 
 import type {FetchOptions} from "jsdom";
@@ -41,6 +41,7 @@ export class CustomResourceLoader extends ResourceLoader {
     }
 
     _fetchJavaScript(url: string): Promise<Buffer> {
+        const logging = getScopedLogger();
         const abortableFetch = fetchPackage(url, "JSDOM", this._requestStats);
         const promiseToBuffer = abortableFetch.then(({content}) => {
             if (!this._active) {
@@ -66,6 +67,7 @@ export class CustomResourceLoader extends ResourceLoader {
     }
 
     fetch(url: string, options: FetchOptions): ?Promise<Buffer> {
+        const logging = getScopedLogger();
         const isInlineData = url.startsWith("data:");
         const loggableUrl = isInlineData ? "inline data" : url;
         if (!this._active) {

--- a/src/custom-resource-loader_test.js
+++ b/src/custom-resource-loader_test.js
@@ -44,7 +44,7 @@ describe("CustomResourceLoader", () => {
             // Arrange
 
             // Act
-            const underTest = new CustomResourceLoader();
+            const underTest = new CustomResourceLoader(logging);
             const result = underTest.isActive;
 
             // Assert
@@ -55,7 +55,7 @@ describe("CustomResourceLoader", () => {
             // Arrange
 
             // Act
-            const underTest = new CustomResourceLoader();
+            const underTest = new CustomResourceLoader(logging);
 
             // Assert
             assert.instanceOf(underTest, ResourceLoader);
@@ -65,7 +65,7 @@ describe("CustomResourceLoader", () => {
     describe("#close", () => {
         it("should set isActive to false", () => {
             // Arrange
-            const underTest = new CustomResourceLoader();
+            const underTest = new CustomResourceLoader(logging);
 
             // Act
             underTest.close();
@@ -80,7 +80,7 @@ describe("CustomResourceLoader", () => {
         describe("when not a JavaScript file", () => {
             it("should return EMPTY promise", () => {
                 // Arrange
-                const underTest = new CustomResourceLoader();
+                const underTest = new CustomResourceLoader(logging);
 
                 // Act
                 const result = underTest.fetch(
@@ -99,7 +99,7 @@ describe("CustomResourceLoader", () => {
                 const fetchPackageSpy = sinon
                     .stub(FetchPackageModule, "default")
                     .returns(new Promise((resolve, reject) => {}));
-                const underTest = new CustomResourceLoader();
+                const underTest = new CustomResourceLoader(logging);
 
                 // Act
                 underTest.fetch("http://example.com/test.js", {});
@@ -107,6 +107,7 @@ describe("CustomResourceLoader", () => {
                 // Assert
                 sinon.assert.calledWith(
                     fetchPackageSpy,
+                    logging,
                     "http://example.com/test.js",
                     "JSDOM",
                 );
@@ -124,7 +125,10 @@ describe("CustomResourceLoader", () => {
                     vmContextSize: 0,
                     createdVmContext: true,
                 };
-                const underTest = new CustomResourceLoader(requestStats);
+                const underTest = new CustomResourceLoader(
+                    logging,
+                    requestStats,
+                );
 
                 // Act
                 underTest.fetch("http://example.com/test.js", {});
@@ -132,6 +136,7 @@ describe("CustomResourceLoader", () => {
                 // Assert
                 sinon.assert.calledWith(
                     fetchPackageSpy,
+                    logging,
                     "http://example.com/test.js",
                     "JSDOM",
                     requestStats,
@@ -144,7 +149,7 @@ describe("CustomResourceLoader", () => {
                 sinon
                     .stub(FetchPackageModule, "default")
                     .returns(Promise.resolve({content}));
-                const underTest = new CustomResourceLoader();
+                const underTest = new CustomResourceLoader(logging);
 
                 // Act
                 // It will not be null $FlowIgnore
@@ -163,7 +168,7 @@ describe("CustomResourceLoader", () => {
                 const fetchPromise = Promise.resolve({content: "CONTENT"});
                 const abortSpy = sinon.spy(fetchPromise, "abort");
                 sinon.stub(FetchPackageModule, "default").returns(fetchPromise);
-                const underTest = new CustomResourceLoader();
+                const underTest = new CustomResourceLoader(logging);
 
                 // Act
                 const result = underTest.fetch(
@@ -186,7 +191,7 @@ describe("CustomResourceLoader", () => {
                         setTimeout(() => resolve({content: ""}), 0);
                     }),
                 );
-                const underTest = new CustomResourceLoader();
+                const underTest = new CustomResourceLoader(logging);
 
                 // Act
                 const fetchPromise = underTest.fetch(
@@ -212,7 +217,7 @@ describe("CustomResourceLoader", () => {
                         setTimeout(() => resolve({content: ""}), 0);
                     }),
                 );
-                const underTest = new CustomResourceLoader();
+                const underTest = new CustomResourceLoader(logging);
 
                 // Act
                 const fetchPromise = underTest.fetch(
@@ -235,7 +240,7 @@ describe("CustomResourceLoader", () => {
             it("should log warning", () => {
                 // Arrange
                 const warnSpy = sinon.spy(logging, "warn");
-                const underTest = new CustomResourceLoader();
+                const underTest = new CustomResourceLoader(logging);
                 underTest.close();
 
                 // Act
@@ -250,7 +255,7 @@ describe("CustomResourceLoader", () => {
 
             it("should return EMPTY", () => {
                 // Arrange
-                const underTest = new CustomResourceLoader();
+                const underTest = new CustomResourceLoader(logging);
                 underTest.close();
 
                 // Act

--- a/src/custom-resource-loader_test.js
+++ b/src/custom-resource-loader_test.js
@@ -2,7 +2,7 @@
 import * as sinon from "sinon";
 import {assert} from "chai";
 import {ResourceLoader} from "jsdom";
-import logging from "./logging.js";
+import {rootLogger as logging} from "./logging.js";
 import * as FetchPackageModule from "./fetch_package.js";
 import {CustomResourceLoader} from "./custom-resource-loader.js";
 

--- a/src/fetch_package.js
+++ b/src/fetch_package.js
@@ -24,6 +24,7 @@ import type {
     JavaScriptPackage,
     RequestStats,
     AbortablePromise,
+    Logger,
 } from "./types.js";
 import type {SuperAgentRequest} from "superagent";
 
@@ -76,6 +77,7 @@ export function flushCache() {
  * containing the content and the url from which it came.
  */
 export default async function fetchPackage(
+    logging: Logger,
     url: string,
     requester: "JSDOM" | "SERVER" | "TEST",
     requestStats?: ?RequestStats,
@@ -134,6 +136,7 @@ export default async function fetchPackage(
             ? ` RETRY#: ${DEFAULT_NUM_RETRIES - triesLeftAfterThisOne}`
             : "";
         const fetchProfile = profile.start(
+            logging,
             `FETCH(${requester}): ${url}${retryText}`,
         );
 
@@ -200,6 +203,7 @@ export default async function fetchPackage(
         // (socket timeout, maybe).  Let's retry a few times.
         if (triesLeftAfterThisOne > 0) {
             return fetchPackage(
+                logging,
                 url,
                 requester,
                 requestStats,

--- a/src/fetch_package_test.js
+++ b/src/fetch_package_test.js
@@ -1,5 +1,5 @@
 // @flow
-
+import {rootLogger} from "./logging.js";
 import fetchPackage, {flushCache} from "./fetch_package.js";
 import args from "./arguments.js";
 import {assert} from "chai";
@@ -29,7 +29,11 @@ describe("fetchPackage", () => {
         mockScope.get("/ok.js").reply(200, "global._fetched = 'yay!';");
 
         // Act
-        const result = await fetchPackage("https://www.ka.org/ok.js", "TEST");
+        const result = await fetchPackage(
+            rootLogger,
+            "https://www.ka.org/ok.js",
+            "TEST",
+        );
 
         // Assert
         assert.isDefined(result);
@@ -46,7 +50,7 @@ describe("fetchPackage", () => {
 
         // Act
         try {
-            await fetchPackage("https://www.ka.org/ok.js", "TEST");
+            await fetchPackage(rootLogger, "https://www.ka.org/ok.js", "TEST");
         } catch (e) {
             // Assert
             assert.equal(404, e.response.status);
@@ -63,8 +67,8 @@ describe("fetchPackage", () => {
 
         // Act
         const result = await Promise.all([
-            fetchPackage("https://www.ka.org/ok.js", "TEST"),
-            fetchPackage("https://www.ka.org/ok.js", "TEST"),
+            fetchPackage(rootLogger, "https://www.ka.org/ok.js", "TEST"),
+            fetchPackage(rootLogger, "https://www.ka.org/ok.js", "TEST"),
         ]);
 
         // Assert
@@ -82,7 +86,7 @@ describe("fetchPackage", () => {
 
         // Act
         try {
-            await fetchPackage("https://www.ka.org/ok.js", "TEST");
+            await fetchPackage(rootLogger, "https://www.ka.org/ok.js", "TEST");
         } catch (e) {
             // Assert
             assert.equal(500, e.response.status);
@@ -99,7 +103,11 @@ describe("fetchPackage", () => {
         mockScope.get("/ok.js").reply(200, "global._fetched = 'yay!';");
 
         // Act
-        const result = await fetchPackage("https://www.ka.org/ok.js", "TEST");
+        const result = await fetchPackage(
+            rootLogger,
+            "https://www.ka.org/ok.js",
+            "TEST",
+        );
 
         // Assert
         assert.equal(result.url, "https://www.ka.org/ok.js");
@@ -113,7 +121,11 @@ describe("fetchPackage", () => {
         mockScope.get("/ok.js").reply(200, "global._fetched = 'yay!';");
 
         // Act
-        const result = await fetchPackage("https://www.ka.org/ok.js", "TEST");
+        const result = await fetchPackage(
+            rootLogger,
+            "https://www.ka.org/ok.js",
+            "TEST",
+        );
 
         // Assert
         assert.equal(result.url, "https://www.ka.org/ok.js");
@@ -149,8 +161,16 @@ describe("fetchPackage with cache", () => {
         mockScope.get("/ok.js").reply(200, "global._fetched = 'ignored';");
 
         // Act
-        const result0 = await fetchPackage("https://www.ka.org/ok.js", "TEST");
-        const result1 = await fetchPackage("https://www.ka.org/ok.js", "TEST");
+        const result0 = await fetchPackage(
+            rootLogger,
+            "https://www.ka.org/ok.js",
+            "TEST",
+        );
+        const result1 = await fetchPackage(
+            rootLogger,
+            "https://www.ka.org/ok.js",
+            "TEST",
+        );
 
         // Assert
         assert.equal(result0.content, result1.content);
@@ -167,7 +187,7 @@ describe("fetchPackage with cache", () => {
 
         // Act
         try {
-            await fetchPackage("https://www.ka.org/ok.js", "TEST");
+            await fetchPackage(rootLogger, "https://www.ka.org/ok.js", "TEST");
         } catch (e) {
             // Assert
             assert.equal(404, e.response.status);
@@ -186,7 +206,7 @@ describe("fetchPackage with cache", () => {
 
         // Act
         try {
-            await fetchPackage("https://www.ka.org/ok.js", "TEST");
+            await fetchPackage(rootLogger, "https://www.ka.org/ok.js", "TEST");
         } catch (e) {
             // Assert
             assert.equal(500, e.response.status);
@@ -204,7 +224,11 @@ describe("fetchPackage with cache", () => {
         mockScope.get("/ok.js").reply(200, "global._fetched = 'yay!';");
 
         // Act
-        const result = await fetchPackage("https://www.ka.org/ok.js", "TEST");
+        const result = await fetchPackage(
+            rootLogger,
+            "https://www.ka.org/ok.js",
+            "TEST",
+        );
 
         // Assert
         assert.equal(result.url, "https://www.ka.org/ok.js");
@@ -218,7 +242,11 @@ describe("fetchPackage with cache", () => {
         mockScope.get("/ok.js").reply(200, "global._fetched = 'yay!';");
 
         // Act
-        const result = await fetchPackage("https://www.ka.org/ok.js", "TEST");
+        const result = await fetchPackage(
+            rootLogger,
+            "https://www.ka.org/ok.js",
+            "TEST",
+        );
 
         // Assert
         assert.equal(result.url, "https://www.ka.org/ok.js");

--- a/src/logging.js
+++ b/src/logging.js
@@ -141,6 +141,15 @@ export async function makeRequestMiddleware(
         : await lw.express.makeMiddleware(logger);
 }
 
-const logger: Logger = initLogging(args.logLevel, args.dev);
+export const rootLogger: Logger = initLogging(args.logLevel, args.dev);
 
-export default logger;
+let scopedLogger: ?Logger = null;
+export const getScopedLogger = (): Logger => {
+    return scopedLogger != null ? scopedLogger : rootLogger;
+};
+export const useScopedLogger = (logger: Logger) => {
+    scopedLogger = logger;
+};
+export const revertScopedLogger = () => {
+    scopedLogger = null;
+};

--- a/src/logging.js
+++ b/src/logging.js
@@ -128,9 +128,7 @@ export function makeErrorMiddleware(logger: Logger): Middleware {
     });
 }
 
-export async function makeRequestMiddleware(
-    logger: Logger,
-): Promise<Middleware> {
+export function makeRequestMiddleware(logger: Logger): Promise<Middleware> {
     // This is the logger that captures requests handled by our express server.
     return args.dev
         ? /**
@@ -157,7 +155,7 @@ export async function makeRequestMiddleware(
         : /**
            * Otherwise, we're using the Google middleware
            */
-          await lw.express.makeMiddleware(logger);
+          lw.express.makeMiddleware(logger);
 }
 
 export const rootLogger: Logger = initLogging(args.logLevel, args.dev);

--- a/src/logging.js
+++ b/src/logging.js
@@ -11,7 +11,7 @@ import * as lw from "@google-cloud/logging-winston";
 
 import args from "./arguments.js";
 
-import type {Middleware} from "express";
+import type {Middleware, $Request} from "express";
 import type {Transport, NpmLogLevels, Format} from "winston";
 import type {Info, Logger, LogLevel} from "./types.js";
 
@@ -162,13 +162,10 @@ export async function makeRequestMiddleware(
 
 export const rootLogger: Logger = initLogging(args.logLevel, args.dev);
 
-let scopedLogger: ?Logger = null;
-export const getScopedLogger = (): Logger => {
-    return scopedLogger != null ? scopedLogger : rootLogger;
-};
-export const useScopedLogger = (logger: Logger) => {
-    scopedLogger = logger;
-};
-export const revertScopedLogger = () => {
-    scopedLogger = null;
+export const getLogger = (req: $Request): Logger => {
+    /**
+     * NOTE: the $Request type doesn't have a log field, officially.
+     * $FlowIgnore
+     */
+    return req.log == null ? rootLogger : req.log;
 };

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,8 @@
 import express from "express";
 
 import args from "./arguments.js";
-import logging, {
+import {
+    rootLogger as logging,
     extractErrorInfo,
     makeErrorMiddleware,
     makeRequestMiddleware,

--- a/src/profile.js
+++ b/src/profile.js
@@ -18,7 +18,7 @@
  *
  *     PROFILE(end): doing foo (40ms)
  */
-import logging from "./logging.js";
+import {getScopedLogger} from "./logging.js";
 
 import type {LogLevel} from "./types.js";
 
@@ -32,6 +32,8 @@ const start = (msg: string): ProfileSession => {
             "Must provide a message or name for the profile session.",
         );
     }
+    const logging = getScopedLogger();
+
     // We use the winston profiling API to do the profiling bit, but we add
     // some additional log entries to aid investigations (like spotting when
     // a profiling task started as winston will only log once profiling is done)

--- a/src/profile.js
+++ b/src/profile.js
@@ -18,21 +18,18 @@
  *
  *     PROFILE(end): doing foo (40ms)
  */
-import {getScopedLogger} from "./logging.js";
-
-import type {LogLevel} from "./types.js";
+import type {LogLevel, Logger} from "./types.js";
 
 type ProfileSession = {
     end: (endMsg?: string, level?: LogLevel) => void,
 };
 
-const start = (msg: string): ProfileSession => {
+const start = (logging: Logger, msg: string): ProfileSession => {
     if (!msg) {
         throw new Error(
             "Must provide a message or name for the profile session.",
         );
     }
-    const logging = getScopedLogger();
 
     // We use the winston profiling API to do the profiling bit, but we add
     // some additional log entries to aid investigations (like spotting when

--- a/src/render.js
+++ b/src/render.js
@@ -6,7 +6,7 @@
  * render, and jsdom (plus a few other things) to provide the
  * necessary context for rendering it.
  */
-import logging from "./logging.js";
+import {getScopedLogger} from "./logging.js";
 import profile from "./profile.js";
 import createRenderContext from "./create-render-context.js";
 import configureApolloNetwork from "./configure-apollo-network.js";
@@ -165,6 +165,7 @@ export default async function render(
     globals: Globals,
     requestStats?: RequestStats,
 ) {
+    const logging = getScopedLogger();
     // Here we get the existing VM context for this request or create a new one
     // and configure it accordingly.
     const context = createRenderContext(

--- a/src/render.js
+++ b/src/render.js
@@ -6,7 +6,6 @@
  * render, and jsdom (plus a few other things) to provide the
  * necessary context for rendering it.
  */
-import {getScopedLogger} from "./logging.js";
 import profile from "./profile.js";
 import createRenderContext from "./create-render-context.js";
 import configureApolloNetwork from "./configure-apollo-network.js";
@@ -16,6 +15,7 @@ import type {
     JavaScriptPackage,
     RenderResult,
     RequestStats,
+    Logger,
 } from "./types.js";
 
 import type {
@@ -160,15 +160,16 @@ const performRender = async (): Promise<RenderResult> => {
  * (https://github.com/Khan/aphrodite).
  */
 export default async function render(
+    logging: Logger,
     jsPackages: Array<JavaScriptPackage>,
     props: mixed,
     globals: Globals,
     requestStats?: RequestStats,
 ) {
-    const logging = getScopedLogger();
     // Here we get the existing VM context for this request or create a new one
     // and configure it accordingly.
     const context = createRenderContext(
+        logging,
         globals ? globals["location"] : "http://www.khanacademy.org",
         globals,
         jsPackages,
@@ -178,6 +179,7 @@ export default async function render(
     context.window.ssrProps = props;
 
     const renderProfile = profile.start(
+        logging,
         `rendering ${(globals && globals["location"]) || ""}`,
     );
 

--- a/src/render_apollo_test.js
+++ b/src/render_apollo_test.js
@@ -2,6 +2,7 @@
 import fs from "fs";
 import {assert} from "chai";
 import render from "./render.js";
+import {rootLogger as logging} from "./logging.js";
 import nock from "nock";
 
 describe("render apollo", () => {
@@ -85,6 +86,7 @@ describe("render apollo", () => {
 
         // Act
         const result = await render(
+            logging,
             packages,
             {},
             {
@@ -111,6 +113,7 @@ describe("render apollo", () => {
 
         // Act
         const result = await render(
+            logging,
             packages,
             {name: "Test Class 1"},
             {
@@ -149,6 +152,7 @@ describe("render apollo", () => {
 
         // Act
         const result = await render(
+            logging,
             packages,
             {},
             {
@@ -177,6 +181,7 @@ describe("render apollo", () => {
 
         // Act
         const underTest = render(
+            logging,
             packages,
             {},
             {
@@ -218,6 +223,7 @@ describe("render apollo", () => {
 
         // Act
         const underTest = render(
+            logging,
             packages,
             {},
             {
@@ -246,6 +252,7 @@ describe("render apollo", () => {
 
         // Act
         const underTest = render(
+            logging,
             packages,
             {},
             {
@@ -273,6 +280,7 @@ describe("render apollo", () => {
 
         // Act
         const underTest = render(
+            logging,
             packages,
             {},
             {
@@ -302,6 +310,7 @@ describe("render apollo", () => {
 
         // Act
         const underTest = render(
+            logging,
             packages,
             {},
             {
@@ -334,6 +343,7 @@ describe("render apollo", () => {
 
         // Act
         const result = await render(
+            logging,
             packages,
             {},
             {
@@ -363,6 +373,7 @@ describe("render apollo", () => {
 
         // Act
         const underTest = render(
+            logging,
             packages,
             {},
             {
@@ -395,6 +406,7 @@ describe("render apollo", () => {
 
         // Act
         const underTest = render(
+            logging,
             packages,
             {},
             {

--- a/src/render_test.js
+++ b/src/render_test.js
@@ -4,6 +4,7 @@ import jsdom from "jsdom";
 import {assert} from "chai";
 import sinon from "sinon";
 import render from "./render.js";
+import {rootLogger as logging} from "./logging.js";
 
 describe("render", () => {
     const loadPackages = (packageNames) =>
@@ -36,7 +37,7 @@ describe("render", () => {
         };
 
         // Act
-        const result = await render(packages, props, {
+        const result = await render(logging, packages, props, {
             location: "https://example.com",
         });
 
@@ -65,7 +66,7 @@ describe("render", () => {
         };
 
         // Act
-        const result = await render(packages, props, {
+        const result = await render(logging, packages, props, {
             location: "https://example.com",
         });
 
@@ -94,7 +95,7 @@ describe("render", () => {
         };
 
         // Act
-        const result = await render(packages, props, {
+        const result = await render(logging, packages, props, {
             location: "https://example.com",
         });
 
@@ -106,6 +107,7 @@ describe("render", () => {
         // Arrange
         const packages = loadPackages(["basic/entry.js"]);
         const expectation = await render(
+            logging,
             packages,
             {name: "A NAME"},
             {
@@ -115,6 +117,7 @@ describe("render", () => {
 
         // Act
         const result = await render(
+            logging,
             packages,
             {name: "A NAME"},
             {
@@ -130,6 +133,7 @@ describe("render", () => {
         // Arrange
         const packages = loadPackages(["basic/entry.js"]);
         const expectation = await render(
+            logging,
             packages,
             {name: "A NAME"},
             {
@@ -139,6 +143,7 @@ describe("render", () => {
 
         // Act
         const result = await render(
+            logging,
             packages,
             {name: "A DIFFERENT NAME"},
             {
@@ -163,6 +168,7 @@ describe("render", () => {
         // All we're testing for here is that this renders without crashing.
         const underTest = async () =>
             await render(
+                logging,
                 packages,
                 {name: "A NAME"},
                 {
@@ -191,7 +197,7 @@ describe("render", () => {
         };
 
         // Act
-        const result = await render(packages, {}, globals);
+        const result = await render(logging, packages, {}, globals);
 
         // Assert
         assert.deepEqual(result, expectation);

--- a/src/secret.js
+++ b/src/secret.js
@@ -13,19 +13,21 @@ import fs from "fs";
 import path from "path";
 
 import args from "./arguments.js";
-import {getScopedLogger} from "./logging.js";
+
+import type {Logger} from "./types.js";
 
 const secretPath: string = path.normalize(__dirname + "/../secret");
 let secret: string;
 
 // Exported for use by the benchmark/loadtest tool.
-export const get = function(done: (?Error, ?string) => void): void {
+export const get = function(
+    logging: Logger,
+    done: (?Error, ?string) => void,
+): void {
     if (secret) {
         done(null, secret);
         return;
     }
-
-    const logging = getScopedLogger();
 
     fs.readFile(secretPath, "utf-8", (err: ?Error, contents: string): void => {
         if (err) {
@@ -51,6 +53,7 @@ export const get = function(done: (?Error, ?string) => void): void {
 };
 
 export const matches = function(
+    logging: Logger,
     actualSecret: string,
     done: (?Error, ?boolean) => void,
 ): void {
@@ -60,7 +63,7 @@ export const matches = function(
         return;
     }
 
-    return get((err: ?Error, secret: ?string): void => {
+    return get(logging, (err: ?Error, secret: ?string): void => {
         if (err) {
             done(err);
             return;

--- a/src/secret.js
+++ b/src/secret.js
@@ -13,7 +13,7 @@ import fs from "fs";
 import path from "path";
 
 import args from "./arguments.js";
-import logging from "./logging.js";
+import {getScopedLogger} from "./logging.js";
 
 const secretPath: string = path.normalize(__dirname + "/../secret");
 let secret: string;
@@ -24,6 +24,8 @@ export const get = function(done: (?Error, ?string) => void): void {
         done(null, secret);
         return;
     }
+
+    const logging = getScopedLogger();
 
     fs.readFile(secretPath, "utf-8", (err: ?Error, contents: string): void => {
         if (err) {

--- a/src/secret_test.js
+++ b/src/secret_test.js
@@ -6,8 +6,13 @@ import {assert} from "chai";
 import sinon from "sinon";
 import args from "./arguments.js";
 import * as renderSecret from "./secret.js";
+import {rootLogger} from "./logging.js";
 
-const matches: (string) => Promise<boolean> = promisify(renderSecret.matches);
+import type {Logger} from "./types.js";
+
+const matches: (Logger, string) => Promise<boolean> = promisify(
+    renderSecret.matches,
+);
 
 describe("secret", () => {
     afterEach(() => {
@@ -28,7 +33,7 @@ describe("secret", () => {
         sinon.stub(args, "dev").get(() => false);
 
         // Act
-        const promise = matches("sekret");
+        const promise = matches(rootLogger, "sekret");
 
         // Assert
         await assert.isRejected(promise, "File not found");
@@ -48,7 +53,7 @@ describe("secret", () => {
         sinon.stub(args, "dev").get(() => false);
 
         // Act
-        const promise = matches("sekret");
+        const promise = matches(rootLogger, "sekret");
 
         // Assert
         await assert.isRejected(promise, "secret file is empty!");
@@ -68,7 +73,7 @@ describe("secret", () => {
         sinon.stub(args, "dev").get(() => false);
 
         // Act
-        const valueMatches = await matches("sekret");
+        const valueMatches = await matches(rootLogger, "sekret");
 
         // Assert
         assert.isTrue(valueMatches, "Should match secret value ");
@@ -92,7 +97,7 @@ describe("secret", () => {
             );
 
         // Act
-        const valueMatches = await matches("sekret");
+        const valueMatches = await matches(rootLogger, "sekret");
 
         // Assert
         assert.isTrue(valueMatches, "Should match secret value ");

--- a/src/server.js
+++ b/src/server.js
@@ -6,12 +6,7 @@
 import bodyParser from "body-parser";
 import express from "express";
 
-import {
-    extractErrorInfo,
-    useScopedLogger,
-    revertScopedLogger,
-    getScopedLogger,
-} from "./logging.js";
+import {extractErrorInfo, getLogger} from "./logging.js";
 import profile from "./profile.js";
 
 import fetchPackage, {flushCache} from "./fetch_package.js";
@@ -19,7 +14,7 @@ import * as renderSecret from "./secret.js";
 import render from "./render.js";
 
 import type {$Request, $Response, NextFunction} from "express";
-import type {RenderBody, RequestStats} from "./types.js";
+import type {Logger, RenderBody, RequestStats} from "./types.js";
 
 // We keep track of how many render requests are currently "in
 // flight", to help us estimate how long a new request will take.
@@ -96,37 +91,22 @@ app.use(
             createdVmContext: false,
         }: RequestStats);
 
-        /**
-         * Before we do any real work, we may have added the log middleware
-         * and we'll want everything to use it. Rather than pass that around
-         * or pass the request around, we can use our logging module and
-         * tell it to scope logging to the request logger during the request.
-         * NOTE: the $Request type doesn't have a log field, officially.
-         * $FlowIgnore
-         */
-        const requestLog: Logger = req.log;
-        if (requestLog != null) {
-            useScopedLogger(requestLog);
-        }
+        const logging = getLogger(req);
 
         pendingRenderRequests++;
-        const renderProfile = profile.start("/render");
+        const renderProfile = profile.start(logging, "/render");
 
         // Register for the response finish so we can finish up our stats.
         res.on("finish", () => {
-            try {
-                pendingRenderRequests--;
-                if (res.statusCode < 300) {
-                    // only log on successful fetches
-                    const renderBody: RenderBody = (req.body: any);
-                    renderProfile.end(
-                        `render-stats for ${
-                            renderBody.urls[renderBody.urls.length - 1]
-                        }: ${JSON.stringify(res.locals.requestStats) || ""}`,
-                    );
-                }
-            } finally {
-                revertScopedLogger();
+            pendingRenderRequests--;
+            if (res.statusCode < 300) {
+                // only log on successful fetches
+                const renderBody: RenderBody = (req.body: any);
+                renderProfile.end(
+                    `render-stats for ${
+                        renderBody.urls[renderBody.urls.length - 1]
+                    }: ${JSON.stringify(res.locals.requestStats) || ""}`,
+                );
             }
         });
         next();
@@ -138,17 +118,23 @@ const checkSecret = function(
     res: $Response,
     next: NextFunction,
 ): mixed {
+    const logging = getLogger(req);
     const {secret}: RenderBody = (req.body: any);
-    renderSecret.matches(secret, (err: ?Error, secretMatches: ?boolean) => {
-        if (err != null || !secretMatches) {
-            res.status(400).send({error: "Missing or invalid secret"});
-            return;
-        }
-        next();
-    });
+    renderSecret.matches(
+        logging,
+        secret,
+        (err: ?Error, secretMatches: ?boolean) => {
+            if (err != null || !secretMatches) {
+                res.status(400).send({error: "Missing or invalid secret"});
+                return;
+            }
+            next();
+        },
+    );
 };
 
 const logAndGetError = function(
+    logging: Logger,
     context: string,
     err: any,
     globals: any,
@@ -168,9 +154,7 @@ const logAndGetError = function(
      * errorString:
      *      The given error as a string.
      */
-    getScopedLogger().error(
-        `${context} (${globals["location"]}): ${errorString}`,
-    );
+    logging.error(`${context} (${globals["location"]}): ${errorString}`);
 
     // Error handler for fetching failures.
     if (err.error && (!err.response || !err.response.error)) {
@@ -184,17 +168,19 @@ const logAndGetError = function(
     };
 };
 
-const respond400Error = (res, error, value) => {
-    getScopedLogger().error(error);
+const respond400Error = (logging: Logger, res: $Response, error, value) => {
+    logging.error(error);
     return res.status(400).json({error, value});
 };
 
 app.post("/render", checkSecret, async (req: $Request, res: $Response) => {
     // Validate the input.
     const {urls, props, globals}: RenderBody = (req.body: any);
+    const logging = getLogger(req);
 
     if (!Array.isArray(urls) || !urls.every((url) => typeof url === "string")) {
         return respond400Error(
+            logging,
             res,
             'Missing "urls" keyword in POST JSON input, ' +
                 'or "urls" is not a list of strings',
@@ -202,6 +188,7 @@ app.post("/render", checkSecret, async (req: $Request, res: $Response) => {
         );
     } else if (typeof props !== "object" || Array.isArray(props)) {
         return respond400Error(
+            logging,
             res,
             'Missing "props" keyword in POST JSON input, ' +
                 'or "props" is not an object, or it has non-string keys.',
@@ -218,6 +205,7 @@ app.post("/render", checkSecret, async (req: $Request, res: $Response) => {
 
     if (jsUrls.length === 0) {
         return respond400Error(
+            logging,
             res,
             'Error in "urls" keyword in POST JSON input, ' +
                 "no valid JS urls were specified.",
@@ -230,11 +218,16 @@ app.post("/render", checkSecret, async (req: $Request, res: $Response) => {
     const fetchPackages = async () => {
         try {
             const fetchPromises = jsUrls.map((url) =>
-                fetchPackage(url, "SERVER", requestStats),
+                fetchPackage(logging, url, "SERVER", requestStats),
             );
             return await Promise.all(fetchPromises);
         } catch (err) {
-            const errorResponse = logAndGetError("FETCH FAIL", err, globals);
+            const errorResponse = logAndGetError(
+                logging,
+                "FETCH FAIL",
+                err,
+                globals,
+            );
             res.status(500).json(errorResponse);
             return null;
         }
@@ -247,6 +240,7 @@ app.post("/render", checkSecret, async (req: $Request, res: $Response) => {
 
     try {
         const renderedState = await render(
+            logging,
             packages,
             props,
             globals,
@@ -261,7 +255,12 @@ app.post("/render", checkSecret, async (req: $Request, res: $Response) => {
         delete renderedState.requestStats;
         res.json(renderedState);
     } catch (err) {
-        const errorResponse = logAndGetError("RENDER FAIL", err, globals);
+        const errorResponse = logAndGetError(
+            logging,
+            "RENDER FAIL",
+            err,
+            globals,
+        );
         // A rendering error is probably a bad component, so we
         // give a 400.
         res.status(400).json(errorResponse);

--- a/src/server_test.js
+++ b/src/server_test.js
@@ -71,7 +71,7 @@ describe("API endpoint /render", function() {
         mockScope = nock("https://www.khanacademy.org");
         sinon
             .stub(renderSecret, "matches")
-            .callsFake((secret, callback) =>
+            .callsFake((logging, secret, callback) =>
                 callback(null, secret === "sekret"),
             );
         errorLoggingSpy = sinon.spy(logging, "error");

--- a/src/server_test.js
+++ b/src/server_test.js
@@ -6,7 +6,7 @@ import sinon from "sinon";
 import supertest from "supertest";
 import * as renderSecret from "./secret.js";
 import server from "./server.js";
-import logging from "./logging.js";
+import {rootLogger as logging} from "./logging.js";
 
 describe("API endpoint /_api/ping", () => {
     const agent = supertest.agent(server);


### PR DESCRIPTION
We middleware that currently is used to profile how long a request takes. This change updates that to also allow us to scope logging to that request. I then update various pieces of our code to use that scoped logger. This allows us to easily get the current logger scope without having to pass the request or its logger around everywhere.

Issue: WEB-1769

## Test Plan
(still running actual tests, but wanted to get the diff up)

1. Update webapp to use this commit using the `yarn update:rrs` command with the commit SHA.
1. Visit the LOHP or other location that SSRs and check that things are logging as we would expect them to
1. [When in prod/znd] See in the stackdriver logging that not only are things logged but they are now grouped beneath the relevant request entry