### PR TITLE
Fix duplicate messages and add info to render log

### DIFF
--- a/flow-typed/npm/winston_v3.x.x.js
+++ b/flow-typed/npm/winston_v3.x.x.js
@@ -74,7 +74,7 @@ declare type $winstonLoggerConfig<T: $winstonLevels> = {
   format?: $winstonFormat,
   level?: $Keys<T>,
   levels?: T,
-  transports?: Array<$winstonTransport>,
+  transports?: $winstonTransport | Array<$winstonTransport>,
   ...
 };
 

--- a/src/logging.js
+++ b/src/logging.js
@@ -34,7 +34,7 @@ function getFormatters() {
     return winston.format.combine(...formatters);
 }
 
-function getTransports(isDev: boolean): Array<Transport> {
+function getTransport(isDev: boolean): Transport {
     if (process.env.NODE_ENV === "test") {
         // During testing, we just dump logging to a stream.
         // This isn't used for anything at all right now, but we could use
@@ -42,29 +42,31 @@ function getTransports(isDev: boolean): Array<Transport> {
         const sink = new stream.Writable({write: () => {}});
         // This is a hack to make our writable stream work $FlowFixMe
         sink._write = sink.write;
-        return [
-            new winston.transports.Stream({
-                format: getFormatters(),
-                stream: sink,
-            }),
-        ];
+        return new winston.transports.Stream({
+            format: getFormatters(),
+            stream: sink,
+        });
     }
 
     /**
      * If we're in dev mode, just use a console transport.
      */
     if (isDev) {
-        return [
-            new winston.transports.Console({
-                format: getFormatters(),
-            }),
-        ];
+        return new winston.transports.Console({
+            format: getFormatters(),
+        });
     }
 
     /**
-     * We must be in production, so use the Stackdriver logging setup.
+     * We must be in production, so we will use the Stackdriver logging setup.
+     * However, we don't need to use our own here as the middleware will do that
+     * for us.
+     *
+     * I repeat, the middleware below will add the logging transport. If we stop
+     * using that middleware, we'll need to add the transport back. We don't
+     * want it to be there twice as that would duplicate log messages.
      */
-    return [new lw.LoggingWinston()];
+    return null;
 }
 
 function initLogging(logLevel: LogLevel, isDev: boolean): Logger {
@@ -72,7 +74,7 @@ function initLogging(logLevel: LogLevel, isDev: boolean): Logger {
     // Whereever one might use console, use this instead.
     const winstonLogger = winston.createLogger<NpmLogLevels>({
         level: logLevel,
-        transports: getTransports(isDev),
+        transports: getTransport(isDev),
     });
 
     winstonLogger.debug(
@@ -147,7 +149,9 @@ export function makeRequestMiddleware(logger: Logger): Promise<Middleware> {
               }),
           )
         : /**
-           * Otherwise, we're using the Google middleware
+           * Otherwise, we're using the Google middleware.
+           * This does some nice things including adding the appropriate
+           * logging transport for us.
            */
           lw.express.makeMiddleware(logger);
 }

--- a/src/logging.js
+++ b/src/logging.js
@@ -59,14 +59,11 @@ function getTransport(isDev: boolean): Transport {
 
     /**
      * We must be in production, so we will use the Stackdriver logging setup.
-     * However, we don't need to use our own here as the middleware will do that
-     * for us.
      *
-     * I repeat, the middleware below will add the logging transport. If we stop
-     * using that middleware, we'll need to add the transport back. We don't
-     * want it to be there twice as that would duplicate log messages.
+     * To avoid getting duplicate entries, make sure this transport is passed
+     * to the middleware method below.
      */
-    return null;
+    return new lw.LoggingWinston();
 }
 
 function initLogging(logLevel: LogLevel, isDev: boolean): Logger {
@@ -153,7 +150,7 @@ export function makeRequestMiddleware(logger: Logger): Promise<Middleware> {
            * This does some nice things including adding the appropriate
            * logging transport for us.
            */
-          lw.express.makeMiddleware(logger);
+          lw.express.makeMiddleware(logger, getTransport(false));
 }
 
 export const rootLogger: Logger = initLogging(args.logLevel, args.dev);

--- a/src/server.js
+++ b/src/server.js
@@ -94,7 +94,10 @@ app.use(
         const logging = getLogger(req);
 
         pendingRenderRequests++;
-        const renderProfile = profile.start(logging, "/render");
+        const renderProfile = profile.start(
+            logging,
+            `/render (active requests: ${pendingRenderRequests})`,
+        );
 
         // Register for the response finish so we can finish up our stats.
         res.on("finish", () => {


### PR DESCRIPTION
The issue is that the `makeMiddleware` function in the `logging-watson` Google package adds its own transport if the second parameter does not indicate that one already exists. This results in two transports and therefore duplicate messages.

My first fix removed our own transport so that the middleware one gets added and is the only transport. This worked mostly except for anything that was logged outside of the express code. In those circumstances we got orphaned log messages and errors about a lack of a transport.

So, the fix I landed on was using our own transport as before, but also telling the middleware about it so that it does not add another. This addresses both the duplicate messages and the need for a transport outside of the express usage.

Unrelated, but low risk; this also adds the number of pending requests to the `/render` profiling just to give us some more date when we're looking at logs and traces.

## Testing
1. Deploy to GAE
2. Following our Confluence guide on testing the RRS, send some render requests and see that the logging is working, both for instance startup that logs outside of the express pipeline, and for subsequent requests inside the pipeline. Note that there are not duplicated entries in a request.
3. Update `webapp` to this commit SHA and verify with `make serve` that the dev experience works correctly still