### PR TITLE
[WEB-1769] Add GAE requestID to logs

### DIFF
--- a/flow-typed/npm/winston_v3.x.x.js
+++ b/flow-typed/npm/winston_v3.x.x.js
@@ -82,6 +82,7 @@ declare type $winstonLogger<T: $winstonLevels> = {
   [$Keys<T>]: (message: string, meta?: Object) => void,
   add: $winstonTransport => void,
   clear: () => void,
+  child: (defaultRequestMetadata: any) => $winstonLogger<T>,
   configure: ($winstonLoggerConfig<T>) => void,
   log: (message: $winstonInfo<T>) => void,
   remove: $winstonTransport => void,

--- a/src/get-request-id.js
+++ b/src/get-request-id.js
@@ -1,0 +1,29 @@
+// @flow
+import type {$Request} from "express";
+
+/**
+ * Get the GAE requestID for a given request if it exists.
+ */
+export const getRequestID = (req: $Request): ?string => {
+    const requestID = req.header("X-Appengine-Request-Log-Id");
+    if (requestID == null) {
+        return null;
+    }
+
+    /**
+     * Per https://github.com/Khan/webapp/blob/57b38a92b5ac8ca912252aa41f3e37e6a9e486fa/web/request/request_id.py#L27-L55
+     * the requestID could be incorrect. Though it's likely that Google fixed
+     * this by now, let's keep the hack as it is harmless and will address the
+     * issue if it remains.
+     *
+     * The "bad" suffixes are all of the form 000101xx and need to be changed to
+     * 000100.
+     */
+    const suffixIndex = requestID.length - 8;
+    const maybeBadSuffix = requestID.substring(suffixIndex);
+
+    if (maybeBadSuffix.startsWith("000101")) {
+        return requestID.substring(0, suffixIndex) + "000100";
+    }
+    return requestID;
+};

--- a/src/get-request-id_test.js
+++ b/src/get-request-id_test.js
@@ -1,0 +1,53 @@
+// @flow
+import {getRequestID} from "./get-request-id.js";
+import {assert} from "chai";
+import sinon from "sinon";
+
+import type {$Request} from "express";
+
+describe("#getRequestID", () => {
+    it("should return null when header is absent", () => {
+        // Arrange
+        const request: $Request = ({
+            header: sinon.stub().withArgs("X-Appengine-Request-Log-Id"),
+        }: any);
+
+        // Act
+        const result = getRequestID(request);
+
+        // Assert
+        assert.isNull(result);
+    });
+
+    it("should return the requestID when it does not end with 000101xx", () => {
+        // Arrange
+        const request: $Request = ({
+            header: sinon
+                .stub()
+                .withArgs("X-Appengine-Request-Log-Id")
+                .returns("this-is-a-good-request-id"),
+        }: any);
+
+        // Act
+        const result = getRequestID(request);
+
+        // Assert
+        assert.equal(result, "this-is-a-good-request-id");
+    });
+
+    it("should return a fixed requestID when it does end with 000101xx", () => {
+        // Arrange
+        const request: $Request = ({
+            header: sinon
+                .stub()
+                .withArgs("X-Appengine-Request-Log-Id")
+                .returns("this-is-a-bad-request-id-000101BD"),
+        }: any);
+
+        // Act
+        const result = getRequestID(request);
+
+        // Assert
+        assert.equal(result, "this-is-a-bad-request-id-000100");
+    });
+});

--- a/src/main.js
+++ b/src/main.js
@@ -17,6 +17,7 @@ import {
     makeErrorMiddleware,
     makeRequestMiddleware,
 } from "./logging.js";
+import {requestIDMiddleware} from "./request-id-middleware.js";
 import app from "./server.js";
 
 async function main() {
@@ -60,8 +61,13 @@ async function main() {
      * The request logger should come before the app, and the error logger, after.
      */
     const appWithLogging = express()
+        // Add request log middleware.
         .use(await makeRequestMiddleware(logging))
+        // Augment request log middleware with GAE requestID.
+        .use(requestIDMiddleware)
+        // Add the app.
         .use(app)
+        // Add error handling middleware.
         .use(makeErrorMiddleware(logging));
 
     /**

--- a/src/request-id-middleware.js
+++ b/src/request-id-middleware.js
@@ -1,5 +1,6 @@
 // @flow
 import {getRequestID} from "./get-request-id.js";
+import type {Logger} from "./types.js";
 import type {$Response, $Request, NextFunction} from "express";
 
 export const requestIDMiddleware = (
@@ -12,7 +13,8 @@ export const requestIDMiddleware = (
      * However, we know that the Google middleware adds it.
      * $FlowIgnore
      */
-    if (req.log == null) {
+    const requestLog: Logger = req.log;
+    if (requestLog == null) {
         // The Google middleware must not be in use. Let's just skip on.
         next();
         return;
@@ -28,11 +30,14 @@ export const requestIDMiddleware = (
     /**
      * We have a requestID and we know req.log exists, so let's replace
      * req.log with a derived child logger that adds the requestID metadata.
-     *
+     */
+
+    const requestIDLog = requestLog.child({requestID});
+    /*
      * NOTE: the $Request type doesn't have a log field, officially.
      * However, we know that the Google middleware adds it.
      * $FlowIgnore
      */
-    req.log = req.log.child({requestID});
+    req.log = requestIDLog;
     next();
 };

--- a/src/request-id-middleware.js
+++ b/src/request-id-middleware.js
@@ -1,0 +1,38 @@
+// @flow
+import {getRequestID} from "./get-request-id.js";
+import type {$Response, $Request, NextFunction} from "express";
+
+export const requestIDMiddleware = (
+    req: $Request,
+    res: $Response,
+    next: NextFunction,
+): void => {
+    /**
+     * NOTE: the $Request type doesn't have a log field, officially.
+     * However, we know that the Google middleware adds it.
+     * $FlowIgnore
+     */
+    if (req.log == null) {
+        // The Google middleware must not be in use. Let's just skip on.
+        next();
+        return;
+    }
+
+    const requestID = getRequestID(req);
+    if (requestID == null) {
+        // We couldn't get the GAE request ID, so let's skip on.
+        next();
+        return;
+    }
+
+    /**
+     * We have a requestID and we know req.log exists, so let's replace
+     * req.log with a derived child logger that adds the requestID metadata.
+     *
+     * NOTE: the $Request type doesn't have a log field, officially.
+     * However, we know that the Google middleware adds it.
+     * $FlowIgnore
+     */
+    req.log = req.log.child({requestID});
+    next();
+};


### PR DESCRIPTION
This PR addresses WEB-1769.

Here we add a middleware right after the Google middleware. This new middleware calculates the requestID from the headers, if it can, and then replaces the `req.log` logger with a child logger that adds the requestID to the log metadata.

## Test Plan
This cannot be tested in dev. We can test in dev that the regular logging works. To do that:
1. Update webapp to this commit SHA of RRS
2. `make serve`
3. Visit LOHP and verify it renders and the RRS logging has output as we might expect

For pre-production testing:
1. Deploy this commit SHA of RRS (*DO NOT* make it default)
2. Use the SSR tooling to test the deployed RRS (see Confluence SSR docs)
3. View the stackdriver logs to see that the log messages have the requestID in their metadata

![image](https://user-images.githubusercontent.com/1266297/74193846-bf91fe00-4c1d-11ea-9fbd-a9a6ba270ea1.png)
Example of this pre-production testing that I conducted using these changes.

For production:
1. Set this commit SHA default
2. Use the production website to SSR the LOHP or other SSR'd pages
3. View the stackdriver logs to see that the log messages have the requestID in their metadata
