### PR TITLE
WEB-1980: Clear unused files from fetch cache to reduce OOM errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2282,9 +2282,8 @@
       }
     },
     "cache-service-cache-module": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/cache-service-cache-module/-/cache-service-cache-module-2.0.1.tgz",
-      "integrity": "sha512-Woh8hheJs6m0Mm5kuqtji/8S/Lh5vyE9hh3E4nCp3ah85CJ4Y4/yegjcUe0kEzW14ZjAE46UJBp3FOsZNVmmGA=="
+      "version": "git+https://git@github.com/Khan/cache-service-cache-module.git#de11094188227c0bd34fcd58b9fe8099805f208d",
+      "from": "git+https://git@github.com/Khan/cache-service-cache-module.git#de11094188227c0bd34fcd58b9fe8099805f208d"
     },
     "cacheable-request": {
       "version": "2.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2282,8 +2282,8 @@
       }
     },
     "cache-service-cache-module": {
-      "version": "git+https://git@github.com/Khan/cache-service-cache-module.git#de11094188227c0bd34fcd58b9fe8099805f208d",
-      "from": "git+https://git@github.com/Khan/cache-service-cache-module.git#de11094188227c0bd34fcd58b9fe8099805f208d"
+      "version": "git+https://git@github.com/Khan/cache-service-cache-module.git#a93afb91ce520b96600229820d1c8189da5b96b3",
+      "from": "git+https://git@github.com/Khan/cache-service-cache-module.git#a93afb91ce520b96600229820d1c8189da5b96b3"
     },
     "cacheable-request": {
       "version": "2.1.4",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "apollo-link-http": "1.5.3",
     "argparse": "^1.0.3",
     "body-parser": "^1.18.3",
-    "cache-service-cache-module": "^2.0.1",
+    "cache-service-cache-module": "git+https://git@github.com/Khan/cache-service-cache-module.git#de11094188227c0bd34fcd58b9fe8099805f208d",
     "express": "^4.17.1",
     "express-winston": "^3.3.0",
     "graphql": "14.1.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "apollo-link-http": "1.5.3",
     "argparse": "^1.0.3",
     "body-parser": "^1.18.3",
-    "cache-service-cache-module": "git+https://git@github.com/Khan/cache-service-cache-module.git#de11094188227c0bd34fcd58b9fe8099805f208d",
+    "cache-service-cache-module": "git+https://git@github.com/Khan/cache-service-cache-module.git#a93afb91ce520b96600229820d1c8189da5b96b3",
     "express": "^4.17.1",
     "express-winston": "^3.3.0",
     "graphql": "14.1.1",

--- a/src/custom-resource-loader.js
+++ b/src/custom-resource-loader.js
@@ -4,7 +4,7 @@ import {applyAbortPatch} from "./patch-promise.js";
 
 import {ResourceLoader} from "jsdom";
 
-import fetchPackage, {flushUnusedCache} from "./fetch_package.js";
+import fetchPackage from "./fetch_package.js";
 
 import type {FetchOptions} from "jsdom";
 import type {RequestStats, Logger} from "./types.js";
@@ -31,11 +31,6 @@ export class CustomResourceLoader extends ResourceLoader {
         this._active = true;
         this._requestStats = requestStats;
         this._logging = logging;
-
-        // Remove any unused files from the fetch_package cache. We do this
-        // before we start any requests to make sure we don't overfill the
-        // cache with all the new data we download.
-        flushUnusedCache();
     }
 
     get isActive(): boolean {

--- a/src/custom-resource-loader.js
+++ b/src/custom-resource-loader.js
@@ -4,7 +4,7 @@ import {applyAbortPatch} from "./patch-promise.js";
 
 import {ResourceLoader} from "jsdom";
 
-import fetchPackage from "./fetch_package.js";
+import fetchPackage, {flushUnusedCache} from "./fetch_package.js";
 
 import type {FetchOptions} from "jsdom";
 import type {RequestStats, Logger} from "./types.js";
@@ -31,6 +31,11 @@ export class CustomResourceLoader extends ResourceLoader {
         this._active = true;
         this._requestStats = requestStats;
         this._logging = logging;
+
+        // Remove any unused files from the fetch_package cache. We do this
+        // before we start any requests to make sure we don't overfill the
+        // cache with all the new data we download.
+        flushUnusedCache();
     }
 
     get isActive(): boolean {

--- a/src/fetch_package.js
+++ b/src/fetch_package.js
@@ -68,6 +68,18 @@ export function flushCache() {
     }
 }
 
+/**
+ * Flush the cache of anything that hasn't been used in the last 15 minutes.
+ */
+export function flushUnusedCache() {
+    /**
+     * Guard this in case we never enabled caching.
+     */
+    if (args.useCache) {
+        cache.flushUnused(15 * 60);
+    }
+}
+
 function isCacheable(url: string): boolean {
     /**
      * For now, let's just cache JS files.
@@ -122,12 +134,12 @@ export default async function fetchPackage(
         /**
          * We're caching.
          *
-         * Set the expiration of the cache at 900 seconds (15 minutes).
-         * This feels reasonable for now.
+         * Set the expiration of the cache to be really high (24 hours) as the
+         * files aren't expected to ever change.
          */
         return fetcher
             .use(superagentCache)
-            .expiration(900)
+            .expiration(24 * 60 * 60)
             .prune((response, gutResponse) => {
                 /**
                  * We want to use our own `prune` method so that we can track

--- a/src/fetch_package.js
+++ b/src/fetch_package.js
@@ -133,25 +133,26 @@ export default async function fetchPackage(
 
         /**
          * We're caching.
-         *
-         * Set the expiration of the cache to be really high (24 hours) as the
-         * files aren't expected to ever change.
          */
-        return fetcher
-            .use(superagentCache)
-            .expiration(24 * 60 * 60)
-            .prune((response, gutResponse) => {
-                /**
-                 * We want to use our own `prune` method so that we can track
-                 * what comes from cache versus what doesn't.
-                 *
-                 * But we still do the same thing that superagent-cache would
-                 * do, for now.
-                 */
-                const guttedResponse = gutResponse(response);
-                guttedResponse._token = token;
-                return guttedResponse;
-            });
+        return (
+            fetcher
+                .use(superagentCache)
+                // Set the expiration of the cache to be really high (24 hours)
+                // as the files aren't expected to ever change.
+                .expiration(24 * 60 * 60)
+                .prune((response, gutResponse) => {
+                    /**
+                     * We want to use our own `prune` method so that we can track
+                     * what comes from cache versus what doesn't.
+                     *
+                     * But we still do the same thing that superagent-cache would
+                     * do, for now.
+                     */
+                    const guttedResponse = gutResponse(response);
+                    guttedResponse._token = token;
+                    return guttedResponse;
+                })
+        );
     };
 
     const doFetch = async (

--- a/src/fetch_package.js
+++ b/src/fetch_package.js
@@ -137,8 +137,10 @@ export default async function fetchPackage(
         return (
             fetcher
                 .use(superagentCache)
-                // Set the expiration of the cache to be really high (24 hours)
-                // as the files aren't expected to ever change.
+                /**
+                 * Set the expiration of the cache to be really high (24 hours)
+                 * as the files aren't expected to ever change.
+                 */
                 .expiration(24 * 60 * 60)
                 .prune((response, gutResponse) => {
                     /**

--- a/src/server.js
+++ b/src/server.js
@@ -244,9 +244,11 @@ app.post("/render", checkSecret, async (req: $Request, res: $Response) => {
     // Fetch the entry point and its dependencies.
     const requestStats: RequestStats = (res.locals.requestStats: any);
     const fetchPackages = async () => {
-        // Remove any unused files from the fetch_package cache. We do this
-        // before we start any requests to make sure we don't overfill the
-        // cache with all the new data we download.
+        /**
+         * Remove any unused files from the fetch_package cache. We do this
+         * before we start any requests to make sure we don't overfill the
+         * cache with all the new data we download.
+         */
         flushUnusedCache();
 
         try {

--- a/src/server.js
+++ b/src/server.js
@@ -9,7 +9,7 @@ import express from "express";
 import {extractErrorInfo, getLogger} from "./logging.js";
 import profile from "./profile.js";
 
-import fetchPackage, {flushCache} from "./fetch_package.js";
+import fetchPackage, {flushCache, flushUnusedCache} from "./fetch_package.js";
 import * as renderSecret from "./secret.js";
 import render from "./render.js";
 
@@ -244,6 +244,11 @@ app.post("/render", checkSecret, async (req: $Request, res: $Response) => {
     // Fetch the entry point and its dependencies.
     const requestStats: RequestStats = (res.locals.requestStats: any);
     const fetchPackages = async () => {
+        // Remove any unused files from the fetch_package cache. We do this
+        // before we start any requests to make sure we don't overfill the
+        // cache with all the new data we download.
+        flushUnusedCache();
+
         try {
             const fetchPromises = jsUrls.map((url) =>
                 fetchPackage(logging, url, "SERVER", requestStats),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1686,9 +1686,9 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
-"cache-service-cache-module@git+https://git@github.com/Khan/cache-service-cache-module.git#de11094188227c0bd34fcd58b9fe8099805f208d":
+"cache-service-cache-module@git+https://git@github.com/Khan/cache-service-cache-module.git#a93afb91ce520b96600229820d1c8189da5b96b3":
   version "2.0.1"
-  resolved "git+https://git@github.com/Khan/cache-service-cache-module.git#de11094188227c0bd34fcd58b9fe8099805f208d"
+  resolved "git+https://git@github.com/Khan/cache-service-cache-module.git#a93afb91ce520b96600229820d1c8189da5b96b3"
 
 cacheable-request@^2.1.1:
   version "2.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1686,10 +1686,9 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
-cache-service-cache-module@^2.0.1:
+"cache-service-cache-module@git+https://git@github.com/Khan/cache-service-cache-module.git#de11094188227c0bd34fcd58b9fe8099805f208d":
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/cache-service-cache-module/-/cache-service-cache-module-2.0.1.tgz#80ec1d97dee78624c3f5d9d5fa9b561fd858e307"
-  integrity sha512-Woh8hheJs6m0Mm5kuqtji/8S/Lh5vyE9hh3E4nCp3ah85CJ4Y4/yegjcUe0kEzW14ZjAE46UJBp3FOsZNVmmGA==
+  resolved "git+https://git@github.com/Khan/cache-service-cache-module.git#de11094188227c0bd34fcd58b9fe8099805f208d"
 
 cacheable-request@^2.1.1:
   version "2.1.4"
@@ -2138,7 +2137,7 @@ debug@3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@^3.1.0, debug@^3.2.6:
+debug@^3.1.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -4421,15 +4420,7 @@ minipass@^2.2.1, minipass@^2.3.4:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
 
-minipass@^2.3.5:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.4.0.tgz#38f0af94f42fb6f34d3d7d82a90e2c99cd3ff485"
-  integrity sha512-6PmOuSP4NnZXzs2z6rbwzLJu/c5gdzYg1mRI/WIYdx45iiX7T+a4esOzavD6V/KmBzAaopFSTZPZcUx73bqKWA==
-  dependencies:
-    safe-buffer "^5.1.2"
-    yallist "^3.0.0"
-
-minizlib@^1.1.1, minizlib@^1.2.1:
+minizlib@^1.1.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.2.1.tgz#dd27ea6136243c7c880684e8672bb3a45fd9b614"
   integrity sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==
@@ -6805,7 +6796,7 @@ yallist@^2.1.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
-yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
+yallist@^3.0.0, yallist@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
   integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==


### PR DESCRIPTION
This ups the cache expiration to 24 hours (as the files themselves shouldn't be changing) and then uses the new logic for clearing the cache of unused files every 15 minutes. I think we'll want to test this in practice to see if there's a duration that makes more sense but I think this is a good starting point.

Related PR: https://github.com/Khan/cache-service-cache-module/pull/1

Issue: https://khanacademy.atlassian.net/browse/WEB-1980

Test plan:
`yarn test` passed. I think the rest we'll want to test in production to see how it works!